### PR TITLE
Revert "build: enable C++20"

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -22,7 +22,7 @@ AM_PATH_PYTHON([3], [AC_SUBST([PYTHON], [echo "$PYTHON"])],
 [AC_MSG_ERROR([Minimum python version(3) not found])])
 
 # Checks for typedefs, structures, and compiler characteristics.
-AX_CXX_COMPILE_STDCXX([20],[noext])
+AX_CXX_COMPILE_STDCXX_17([noext])
 AX_APPEND_COMPILE_FLAGS([-Wall -Werror], [CXXFLAGS])
 
 # Checks for libraries.


### PR DESCRIPTION
The autotools-archive recipe doesn't have the updates to let it support
C++20.

This reverts commit a0594a0c60bc78fbed4d588fad12afe9a1cb6f4c.