### PR TITLE
control: Be more lenient toward missing sensors

### DIFF
--- a/control/json/manager.cpp
+++ b/control/json/manager.cpp
@@ -569,10 +569,16 @@ void Manager::addObjects(const std::string& path, const std::string& intf,
     {
         // No object manager interface provided by service?
         // Attempt to retrieve property directly
-        auto value = util::SDBusPlus::getPropertyVariant<PropertyVariantType>(
-            _bus, service, path, intf, prop);
+        try
+        {
+            auto value =
+                util::SDBusPlus::getPropertyVariant<PropertyVariantType>(
+                    _bus, service, path, intf, prop);
 
-        setProperty(path, intf, prop, value);
+            setProperty(path, intf, prop, value);
+        }
+        catch (const std::exception& e)
+        {}
         return;
     }
 
@@ -690,13 +696,17 @@ void Manager::addGroups(const std::vector<Group>& groups)
                     {
                         // No object manager interface provided for group member
                         // Attempt to retrieve group member property directly
-                        auto value = util::SDBusPlus::getPropertyVariant<
-                            PropertyVariantType>(_bus, service, member,
-                                                 group.getInterface(),
-                                                 group.getProperty());
-
-                        setProperty(member, group.getInterface(),
-                                    group.getProperty(), value);
+                        try
+                        {
+                            auto value = util::SDBusPlus::getPropertyVariant<
+                                PropertyVariantType>(_bus, service, member,
+                                                     group.getInterface(),
+                                                     group.getProperty());
+                            setProperty(member, group.getInterface(),
+                                        group.getProperty(), value);
+                        }
+                        catch (const std::exception& e)
+                        {}
                         continue;
                     }
 

--- a/control/json/triggers/init.cpp
+++ b/control/json/triggers/init.cpp
@@ -65,7 +65,7 @@ void getProperties(Manager* mgr, const Group& group)
                 }
             }
         }
-        catch (const util::DBusMethodError& dme)
+        catch (const std::exception& e)
         {
             // Configured dbus object does not exist on dbus yet?
             // TODO How to handle this? Create timer to keep checking for


### PR DESCRIPTION
In the cases where the service name of a sensor (i.e. group member) is
known ahead of time, but that service isn't actually running, the code
will try to make a get property call on it anyway and crash.  Fix that
by catching the exception and continuing on.

Also, if the same type of service isn't running but is used in an action
that runs on a timer with 'preload_groups' set in the config to have the
code try to get all properties in the groups after each timer
expiration, there will be an exception thrown there too.  In that case,
the exception is caught by the sdeventplus handler so the app doesn't
crash, but it prevents the run() call from completing.  Catch that
exception as well in Manager::addGroups() so the actions can complete.

This is merged in master.

Signed-off-by: Matt Spinler <spinler@us.ibm.com>
Change-Id: Ifb56333508c3ceb6027e1e004d946c330dbd8634