### PR TITLE
monitor:configs:rainier-2u: EPOW config changes

### DIFF
--- a/monitor/config_files/p10bmc/ibm,rainier-2u/config.json
+++ b/monitor/config_files/p10bmc/ibm,rainier-2u/config.json
@@ -169,9 +169,9 @@
             {
                 "type": "epow",
                 "cause": "nonfunc_fan_rotors",
-                "count": 3,
-                "service_mode_delay": 300,
-                "meltdown_delay": 300
+                "count": 2,
+                "service_mode_delay": 60,
+                "meltdown_delay": 60
             }
        ]
    }


### PR DESCRIPTION
Change the number of failed rotors required to power off to 2, and both
the service mode and meltdown delays to 1 minute.

Signed-off-by: Matt Spinler <spinler@us.ibm.com>
Change-Id: Iecc8dd167e5926bb0f180a040a993c9284adcbbd