### PR TITLE
monitor:configs:rainier-4u: EPOW config changes

### DIFF
--- a/monitor/config_files/p10bmc/ibm,rainier-1s4u/config.json
+++ b/monitor/config_files/p10bmc/ibm,rainier-1s4u/config.json
@@ -90,8 +90,8 @@
                 "type": "epow",
                 "cause": "nonfunc_fan_rotors",
                 "count": 2,
-                "service_mode_delay": 300,
-                "meltdown_delay": 300
+                "service_mode_delay": 60,
+                "meltdown_delay": 60
             }
        ]
    }

--- a/monitor/config_files/p10bmc/ibm,rainier-4u/config.json
+++ b/monitor/config_files/p10bmc/ibm,rainier-4u/config.json
@@ -126,8 +126,8 @@
                 "type": "epow",
                 "cause": "nonfunc_fan_rotors",
                 "count": 2,
-                "service_mode_delay": 300,
-                "meltdown_delay": 300
+                "service_mode_delay": 60,
+                "meltdown_delay": 60
             }
        ]
    }


### PR DESCRIPTION
Change the service mode and meltdown delays to 1 minute on the rainier
4U and 1S4U.

Signed-off-by: Matt Spinler <spinler@us.ibm.com>
Change-Id: I62e648e60194937dff376d686c6a34bed59a9a58