### PR TITLE
Revert "control:configs:ibm,everest: Change 11300 -> 11000"

### DIFF
--- a/control/config_files/p10bmc/ibm,everest/events.json
+++ b/control/config_files/p10bmc/ibm,everest/events.json
@@ -24,7 +24,7 @@
          "name": "count_state_before_target",
          "count": 1,
          "state": false,
-         "target": 11000
+         "target": 11300
        }
      ]
    },
@@ -68,7 +68,7 @@
          "name": "count_state_before_target",
          "count": 2,
          "state": false,
-         "target": 11000
+         "target": 11300
        }
      ]
    },
@@ -202,7 +202,7 @@
         "name": "count_state_floor",
         "count": 1,
         "state": false,
-        "floor": 11000
+        "floor": 11300
       }
     ]
   },
@@ -370,7 +370,7 @@
         "name": "count_state_floor",
         "count": 1,
         "state": false,
-        "floor": 11000
+        "floor": 11300
       }
     ]
   },

--- a/control/config_files/p10bmc/ibm,everest/zones.json
+++ b/control/config_files/p10bmc/ibm,everest/zones.json
@@ -1,8 +1,8 @@
 [
     {
         "name": "0",
-        "poweron_target": 11000,
-        "default_floor": 11000,
+        "poweron_target": 11300,
+        "default_floor": 11300,
         "increase_delay": 5,
         "decrease_interval": 15
     }


### PR DESCRIPTION
This reverts commit cd6c66882613ed248e048a338d775653da881f34.

Turns out the fans need to be allowed to go to 11300 to help with high
altitude systems.

Change-Id: I29ed5dc2b9d31de893acd18051e7b28addc17fee

