### PR TITLE
control:p10bmc:rainier-1s4u: 4000 -> 3700 floor

### DIFF
--- a/control/config_files/p10bmc/ibm,rainier-1s4u/events.json
+++ b/control/config_files/p10bmc/ibm,rainier-1s4u/events.json
@@ -1078,7 +1078,7 @@
           {
             // Entry valid for ambient temp < 27
             "key": 27,
-            "default_floor": 4000,
+            "default_floor": 3700,
             "floor_offset_parameter": "altitude_offset",
             "floors": [
               {
@@ -1086,20 +1086,20 @@
                 "floors": [
                   {
                     "value": "xyz.openbmc_project.Control.Power.Mode.PowerMode.Static",
-                    "floor": 4000
+                    "floor": 3700
                   },
                   {
                     "value": "xyz.openbmc_project.Control.Power.Mode.PowerMode.PowerSaving",
-                    "floor": 4000
+                    "floor": 3700
                   },
                   {
                     "value": "xyz.openbmc_project.Control.Power.Mode.PowerMode.MaximumPerformance",
-                    "floor": 4000
+                    "floor": 3700
                   },
                   {
                     // OEM == MaximumPerformance
                     "value": "xyz.openbmc_project.Control.Power.Mode.PowerMode.OEM",
-                    "floor": 4000
+                    "floor": 3700
                   }
                 ]
               },


### PR DESCRIPTION
Lower the floor from 4000 to 3700 in the lowest ambient table.  This is
for acoustic reasons.

Signed-off-by: Matt Spinler <spinler@us.ibm.com>
Change-Id: I082c7e75a65662f0cf1b328d5da9d0006c2da57e