### PR TITLE
control: Fix InterfacesRemoved match string

### DIFF
--- a/control/json/triggers/signal.cpp
+++ b/control/json/triggers/signal.cpp
@@ -148,8 +148,9 @@ void interfacesRemoved(Manager* mgr, const Group& group,
     // will do nothing since signals require a group
     for (const auto& member : group.getMembers())
     {
-        // Setup interfaces added signal handler on the group member
-        const auto match = rules::interfacesRemoved(member);
+        // Setup interfaces removed signal handler on the group member
+        const auto match =
+            rules::interfacesRemoved() + rules::argNpath(0, member);
         SignalPkg signalPkg = {Handlers::interfacesRemoved,
                                SignalObject(std::cref(member),
                                             std::cref(group.getInterface()),


### PR DESCRIPTION
The interfaces_removed trigger was using the wrong match for the
InterfacesRemoved signal.  It was trying look for the object path in
question to be the 'path' field, but 'path' is just the path of the
object manager sending the signal.  It should be looking at argument 0
instead.  This was previously fixed for InterfacesAdded but somehow
missed for this one.

Signed-off-by: Matt Spinler <spinler@us.ibm.com>
Change-Id: If818b228472606dd204d507cfe04c7bacdc5fc03