### PR TITLE
control:cnfgs:p10bmc: Add svc names to some groups

### DIFF
--- a/control/config_files/p10bmc/ibm,everest/groups.json
+++ b/control/config_files/p10bmc/ibm,everest/groups.json
@@ -904,6 +904,7 @@
  },
  {
    "name": "planar temps",
+   "service": "xyz.openbmc_project.HwmonTempSensor",
    "members": [
      "/xyz/openbmc_project/sensors/temperature/PCIE_0_Temp",
      "/xyz/openbmc_project/sensors/temperature/PCIE_1_Temp"
@@ -929,12 +930,14 @@
  },
  {
    "name": "ambient temp",
+   "service": "xyz.openbmc_project.VirtualSensor",
    "members": [
       "/xyz/openbmc_project/sensors/temperature/Ambient_Virtual_Temp"
    ]
  },
  {
    "name": "altitude",
+   "service": "xyz.openbmc_project.VirtualSensor",
    "members": [
       "/xyz/openbmc_project/sensors/altitude/Altitude"
    ]

--- a/control/config_files/p10bmc/ibm,rainier-1s4u/groups.json
+++ b/control/config_files/p10bmc/ibm,rainier-1s4u/groups.json
@@ -310,6 +310,7 @@
  },
  {
    "name": "planar temps",
+   "service": "xyz.openbmc_project.HwmonTempSensor",
    "members": [
      "/xyz/openbmc_project/sensors/temperature/PCIE_0_Temp",
      "/xyz/openbmc_project/sensors/temperature/PCIE_1_Temp"
@@ -337,6 +338,7 @@
  },
  {
    "name": "ambient temp",
+   "service": "xyz.openbmc_project.VirtualSensor",
    "members": [
       "/xyz/openbmc_project/sensors/temperature/Ambient_Virtual_Temp"
    ]
@@ -365,6 +367,7 @@
  },
  {
    "name": "power mode",
+   "service": "org.open_power.OCC.Control",
    "members": [
      "/xyz/openbmc_project/control/host0/power_mode"
    ]

--- a/control/config_files/p10bmc/ibm,rainier-2u/groups.json
+++ b/control/config_files/p10bmc/ibm,rainier-2u/groups.json
@@ -514,6 +514,7 @@
  },
  {
    "name": "planar temps",
+   "service": "xyz.openbmc_project.HwmonTempSensor",
    "members": [
      "/xyz/openbmc_project/sensors/temperature/PCIE_0_Temp",
      "/xyz/openbmc_project/sensors/temperature/PCIE_1_Temp"
@@ -545,12 +546,14 @@
  },
  {
    "name": "ambient temp",
+   "service": "xyz.openbmc_project.VirtualSensor",
    "members": [
       "/xyz/openbmc_project/sensors/temperature/Ambient_Virtual_Temp"
    ]
  },
  {
    "name": "altitude",
+   "service": "xyz.openbmc_project.VirtualSensor",
    "members": [
       "/xyz/openbmc_project/sensors/altitude/Altitude"
    ]

--- a/control/config_files/p10bmc/ibm,rainier-4u/groups.json
+++ b/control/config_files/p10bmc/ibm,rainier-4u/groups.json
@@ -526,6 +526,7 @@
  },
  {
    "name": "planar temps",
+   "service": "xyz.openbmc_project.HwmonTempSensor",
    "members": [
      "/xyz/openbmc_project/sensors/temperature/PCIE_0_Temp",
      "/xyz/openbmc_project/sensors/temperature/PCIE_1_Temp"
@@ -557,6 +558,7 @@
  },
  {
    "name": "ambient temp",
+   "service": "xyz.openbmc_project.VirtualSensor",
    "members": [
       "/xyz/openbmc_project/sensors/temperature/Ambient_Virtual_Temp"
    ]
@@ -595,6 +597,7 @@
  },
  {
    "name": "power mode",
+   "service": "org.open_power.OCC.Control",
    "members": [
      "/xyz/openbmc_project/control/host0/power_mode"
    ]


### PR DESCRIPTION
The group configuration files provide the ability to add the D-Bus service owner of the group, if it's known and if there is only one service providing everything in the group.  If that is provided, then fan control can register for a NameOwnerChanged signal if that service starts after fan control.

For that reason, add service names to some of the groups that were missing one.  It is most important for the virtual ambient group, where it was seen that it could start after fan control so fan control was setting the fan targets to a higher value than necessary.

Note that the service name isn't needed for any of the inventory related groups because they aren't used in the 'services missing' event.

There is a TODO in the code to figure out how to handle this case when the service name can't be hardcoded, maybe by adding a timer to do some retries.  That may be done in the future.

Signed-off-by: Matt Spinler <spinler@us.ibm.com>
Change-Id: I1b42e67b6824e7c31a5eef3ecaddfd8ec2487224