### PR TITLE
control:configs: Add altitude group to Rainier 4Us

### DIFF
--- a/control/config_files/p10bmc/ibm,rainier-1s4u/groups.json
+++ b/control/config_files/p10bmc/ibm,rainier-1s4u/groups.json
@@ -344,6 +344,11 @@
    ]
  },
  {
+   "name": "altitude",
+   "service": "xyz.openbmc_project.VirtualSensor",
+   "members": ["/xyz/openbmc_project/sensors/altitude/Altitude"]
+ },
+ {
    "name": "pcie cards",
    "members": [
      "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot6/pcie_card6",

--- a/control/config_files/p10bmc/ibm,rainier-4u/groups.json
+++ b/control/config_files/p10bmc/ibm,rainier-4u/groups.json
@@ -564,6 +564,11 @@
    ]
  },
  {
+   "name": "altitude",
+   "service": "xyz.openbmc_project.VirtualSensor",
+   "members": ["/xyz/openbmc_project/sensors/altitude/Altitude"]
+ },
+ {
    "name": "pcie cards",
    "members": [
      "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot0/pcie_card0",


### PR DESCRIPTION
The altitude is used by actions in the Rainier 4U and 1S4U, but was missing from the groups.json files. This caused the altitude offsets used by the mapped floor action to always be zero.

Signed-off-by: Matt Spinler <spinler@us.ibm.com>
Change-Id: I46748a9dfe5f054964c11ae28009c0c73b23b1fc