### PR TITLE
Fan control code support for floor table conditions

### DIFF
--- a/control/json/actions/mapped_floor.hpp
+++ b/control/json/actions/mapped_floor.hpp
@@ -101,6 +101,17 @@ using json = nlohmann::json;
  *   3. The default floor in the zone config
  *     - Chosen when when 2. would be used, but it wasn't supplied
  *
+ * This action can also have a condition specified where a group property
+ * must either match or not match a given value to determine if the
+ * action should run or not.  This requires the following in the JSON:
+ *    "condition_group": The group name
+ *       - As of now, group must just have a single member.
+ *    "condition_op": Either "equal" or "not_equal"
+ *    "condition_value": The value to check against
+ *
+ * This allows completely separate mapped_floor actions to run based on
+ * the value of a D-bus property - i.e. it allows multiple floor tables.
+ *
  * Other notes:
  *  - If a group has multiple members, they must be numeric or else
  *    the code will throw an exception.
@@ -113,7 +124,6 @@ using json = nlohmann::json;
  *    it can be:
  *            "parameter": "some_parameter"
  */
-
 class MappedFloor : public ActionBase, public ActionRegister<MappedFloor>
 {
   public:
@@ -165,6 +175,13 @@ class MappedFloor : public ActionBase, public ActionRegister<MappedFloor>
     void setFloorTable(const json& jsonObj);
 
     /**
+     * @brief Parse and set the conditions
+     *
+     * @param jsonObj - JSON object for the action
+     */
+    void setCondition(const json& jsonObj);
+
+    /**
      * @brief Applies the offset in offsetParameter to the
      *        value passed in.
      *
@@ -207,8 +224,25 @@ class MappedFloor : public ActionBase, public ActionRegister<MappedFloor>
      */
     const Group* getGroup(const std::string& name);
 
+    /**
+     * @brief Checks if the condition is met, if there is one.
+     *
+     * @return bool - False if there is a condition and it
+     *                isn't met, true otherwise.
+     */
+    bool meetsCondition();
+
     /* Key group pointer */
     const Group* _keyGroup;
+
+    /* condition group pointer */
+    const Group* _conditionGroup = nullptr;
+
+    /* Condition value */
+    PropertyVariantType _conditionValue;
+
+    /* Condition operation */
+    std::string _conditionOp;
 
     /* Optional default floor value for the action */
     std::optional<uint64_t> _defaultFloor;

--- a/control/json/zone.hpp
+++ b/control/json/zone.hpp
@@ -264,6 +264,17 @@ class Zone : public ConfigBase
     void setFloorHold(const std::string& ident, uint64_t target, bool hold);
 
     /**
+     * @brief Says if the passed in identity has a floor hold
+     *
+     * @param ident - The identity key to check
+     * @return bool - If it has a floor hold or not
+     */
+    inline bool hasFloorHold(const std::string& ident) const
+    {
+        return _floorHolds.contains(ident);
+    }
+
+    /**
      * @brief Set the default floor to the given value
      *
      * @param[in] value - Value to set the default floor to

--- a/docs/control/events.md
+++ b/docs/control/events.md
@@ -457,6 +457,35 @@ default to the default floor of the zone.
 At the end of the analysis, a floor hold will be set with the final floor
 value.
 
+This action can also have a condition specified where a group property must
+either match or not match a given value to determine if the action should run or
+not. This requires the following in the JSON:
+
+- "condition_group": The group name
+  - For now, this group must just have a single member.
+- "condition_op": Either "equal" or "not_equal"
+- "condition_value": The value to check against
+
+For example, the following says the single member of the 'cpu 0' group must have
+its Model property be equal to "1234" for the action to run:
+
+```
+    "groups": [{
+        "name": "cpu 0",
+        "interface": "xyz.openbmc_project.Inventory.Decorator.Asset",
+        "property": { "name": "Model" }
+      }
+      ...
+    ],
+    ...
+    "name": "mapped_floor",
+    "key_group": "ambient temp",
+    "condition_group": "cpu 0",
+    "condition_value": "1234",
+    "condition_op": "equal",
+    ...
+```
+
 ### set_target_on_missing_owner
 Sets the fans to a configured target when any service owner associated to the
 group is missing. Once all services are functional and providing all the


### PR DESCRIPTION
This code is needed to process the 'condition' keywords that were added to the mapped_floor tables for the Rainier 1s4U in an earlier commit.  This allows a different floor table to be selected based on some D-Bus property value.