### PR TITLE
control:configs:rainier-*4u: Add new hot card

### DIFF
--- a/control/config_files/p10bmc/ibm,rainier-1s4u/pcie_cards.json
+++ b/control/config_files/p10bmc/ibm,rainier-1s4u/pcie_cards.json
@@ -191,6 +191,14 @@
       "subsystem_vendor_id": "0x1014",
       "subsystem_id": "0x0614",
       "floor_index": 1
+    },
+    {
+      "name": "Dragonhead",
+      "vendor_id": "0x1077",
+      "device_id": "0x2089",
+      "subsystem_vendor_id": "0x1014",
+      "subsystem_id": "0x06C6",
+      "floor_index": 3
     }
   ]
 }

--- a/control/config_files/p10bmc/ibm,rainier-4u/pcie_cards.json
+++ b/control/config_files/p10bmc/ibm,rainier-4u/pcie_cards.json
@@ -207,6 +207,14 @@
       "subsystem_vendor_id": "0x1014",
       "subsystem_id": "0x0614",
       "floor_index": 1
+    },
+    {
+      "name": "Dragonhead",
+      "vendor_id": "0x1077",
+      "device_id": "0x2089",
+      "subsystem_vendor_id": "0x1014",
+      "subsystem_id": "0x06C6",
+      "floor_index": 3
     }
   ]
 }


### PR DESCRIPTION
Add the Dragonhead PCIe card to the hot cards list pcie_cards.json for the Rainier 4U and 1S4U.


Change-Id: Idd355a350f39e0c8739fd3c68f16840f7da70cec

