### PR TITLE
control:configs:rainier-2u: Add new hot card

### DIFF
--- a/control/config_files/p10bmc/ibm,rainier-2u/pcie_cards.json
+++ b/control/config_files/p10bmc/ibm,rainier-2u/pcie_cards.json
@@ -175,6 +175,14 @@
       "subsystem_vendor_id": "0x1014",
       "subsystem_id": "0x06A4",
       "floor_index": 5
+    },
+    {
+      "name": "Lassen 2 Port IB",
+      "vendor_id": "0x15B3",
+      "device_id": "0x1019",
+      "subsystem_vendor_id": "0x1014",
+      "subsystem_id": "0x0617",
+      "floor_index": 5
     }
   ]
 }


### PR DESCRIPTION
Add the Lassen InfiniBand adapter to the hot cards list for the Rainier 2U.


Change-Id: I88f84068f2e22e743fdd764b17914383ea3371a0