### PR TITLE
Add 5 second delay before changing floors due to nonfunctional sensors

### DIFF
--- a/control/config_files/p10bmc/ibm,everest/events.json
+++ b/control/config_files/p10bmc/ibm,everest/events.json
@@ -489,6 +489,7 @@
                 "name": "count_state_floor",
                 "count": 1,
                 "state": false,
+                "delay": 5,
                 "floor": 11300
             }
         ]

--- a/control/config_files/p10bmc/ibm,rainier-1s4u/events.json
+++ b/control/config_files/p10bmc/ibm,rainier-1s4u/events.json
@@ -314,6 +314,7 @@
                 "name": "count_state_floor",
                 "count": 1,
                 "state": false,
+                "delay": 5,
                 "floor": 10400
             }
         ]

--- a/control/config_files/p10bmc/ibm,rainier-2u/events.json
+++ b/control/config_files/p10bmc/ibm,rainier-2u/events.json
@@ -532,6 +532,7 @@
                 "name": "count_state_floor",
                 "count": 1,
                 "state": false,
+                "delay": 5,
                 "floor": 18000
             }
         ]

--- a/control/config_files/p10bmc/ibm,rainier-4u/events.json
+++ b/control/config_files/p10bmc/ibm,rainier-4u/events.json
@@ -344,6 +344,7 @@
                 "name": "count_state_floor",
                 "count": 1,
                 "state": false,
+                "delay": 5,
                 "floor": 10400
             }
         ]

--- a/control/json/actions/count_state_floor.hpp
+++ b/control/json/actions/count_state_floor.hpp
@@ -40,6 +40,9 @@ using json = nlohmann::json;
  *      "state": false,
  *      "floor": 5000
  *    }
+ *
+ * There is an optional 'delay' field that that prevents the floor from
+ * being changed until the count has been met for that amount of time.
  */
 class CountStateFloor :
     public ActionBase,
@@ -104,6 +107,20 @@ class CountStateFloor :
      */
     void setFloor(const json& jsonObj);
 
+    /**
+     * @brief Parse and set the delay
+     *
+     * @param[in] jsonObj - JSON object for the action
+     */
+    void setDelayTime(const json& jsonObj);
+
+    /**
+     * @brief Counts the number of members that are equal to the state.
+     *
+     * @return bool - If the count is reached or not.
+     */
+    bool doCount();
+
     /* Number of group members */
     size_t _count;
 
@@ -112,6 +129,12 @@ class CountStateFloor :
 
     /* Floor for this action */
     uint64_t _floor;
+
+    /* Amount of time the count has to be met */
+    std::chrono::seconds _delayTime{0};
+
+    /* Timer used for checking the delay */
+    std::unique_ptr<Timer> _timer;
 };
 
 } // namespace phosphor::fan::control::json

--- a/docs/control/events.md
+++ b/docs/control/events.md
@@ -396,14 +396,15 @@ below the configured count, the floor hold is released.
     "name": "count_state_floor",
     "count": 2,
     "state": false,
-    "floor": 18000
+    "floor": 18000,
+    "delay": 3
 }
 ```
 
 The above config reads the configured D-Bus property on each group member
-configured for the action. If two or more members have a property value of
-false, a floor hold will be requested with a value of 18000. Otherwise, the
-floor hold will be released (if it was previously requested).
+configured for the action. If two or more members have a property value of false
+for 3 seconds, a floor hold will be requested with a value of 18000. Otherwise,
+the floor hold will be released (if it was previously requested).
 
 ### count_state_before_target
 


### PR DESCRIPTION
Prevent fans from jumping to the high floor due to temp sensors being nonfunctional for less than 5 seconds.
This fixes a problem when a drive is removed and the NVMe temp sensors briefly go to nonfunctional.

Upstream: https://gerrit.openbmc.org/c/openbmc/phosphor-fan-presence/+/68613

Defect 589453