### PR TITLE
control:Bonnell: Update dram temp thresholds

### DIFF
--- a/control/config_files/p10bmc/ibm,bonnell/events.json
+++ b/control/config_files/p10bmc/ibm,bonnell/events.json
@@ -416,7 +416,7 @@
                         "property": { "name": "Value" }
                     }
                 ],
-                "state": 68.0,
+                "state": 64.0,
                 "delta": 100
             },
             {
@@ -488,7 +488,7 @@
                         "property": { "name": "Value" }
                     }
                 ],
-                "state": 65.0,
+                "state": 61.0,
                 "delta": 40
             },
             {


### PR DESCRIPTION
Move the dram temp range to 64-61 from 68-65.


Change-Id: I0f3847e70e59e8cd15e5934827c9d3df23530bb6