### PR TITLE
Rainier 2U: Don't power off if both rotors in same fan fail

### DIFF
--- a/docs/monitor/power_off_config.md
+++ b/docs/monitor/power_off_config.md
@@ -19,6 +19,8 @@ nonfunctional fans.
   - "missing_fan_frus" - Power off due to missing fan enclosures
   - "nonfunc_fan_rotors" - Power off due to nonfunctional fan
     rotors([`sensors`](sensors.md))
+  - "fan_frus_with_nonfunc_rotors" - Power off due to the number of fan FRUs
+    with at least one nonfunctional rotor.
 - `count` - integer
   - Number of the configured `cause` instances to begin the power off `type`
 

--- a/monitor/config_files/p10bmc/ibm,rainier-2u/config.json
+++ b/monitor/config_files/p10bmc/ibm,rainier-2u/config.json
@@ -158,15 +158,15 @@
 
         "power_off_config": [
             {
-                "type": "hard",
+                "type": "epow",
                 "cause": "missing_fan_frus",
                 "count": 1,
-                "delay": 25,
-                "state": "at_pgood"
+                "service_mode_delay": 60,
+                "meltdown_delay": 60
             },
             {
                 "type": "epow",
-                "cause": "nonfunc_fan_rotors",
+                "cause": "fan_frus_with_nonfunc_rotors",
                 "count": 2,
                 "service_mode_delay": 60,
                 "meltdown_delay": 60

--- a/monitor/json_parser.cpp
+++ b/monitor/json_parser.cpp
@@ -436,8 +436,12 @@ std::unique_ptr<PowerOffCause> getPowerOffCause(const json& powerOffConfig)
         causes{
             {"missing_fan_frus",
              [count]() { return std::make_unique<MissingFanFRUCause>(count); }},
-            {"nonfunc_fan_rotors", [count]() {
+            {"nonfunc_fan_rotors",
+             [count]() {
         return std::make_unique<NonfuncFanRotorCause>(count);
+    }},
+            {"fan_frus_with_nonfunc_rotors", [count]() {
+        return std::make_unique<FanFRUsWithNonfuncRotorsCause>(count);
     }}};
 
     auto it = causes.find(powerOffCause);

--- a/monitor/power_off_cause.hpp
+++ b/monitor/power_off_cause.hpp
@@ -138,7 +138,7 @@ class NonfuncFanRotorCause : public PowerOffCause
      * @brief Constructor
      *
      * @param[in] count - The minimum number of rotors that must be
-     *                    nonfunctional nonfunctional to need a power off.
+     *                    nonfunctional to need a power off.
      */
     explicit NonfuncFanRotorCause(size_t count) :
         PowerOffCause(count, "Nonfunctional Fan Rotors")
@@ -158,6 +158,55 @@ class NonfuncFanRotorCause : public PowerOffCause
             auto nonFuncTachs = std::count_if(tachs.begin(), tachs.end(),
                                               [](bool tach) { return !tach; });
             return sum + nonFuncTachs;
+        });
+
+        return count >= _count;
+    }
+};
+
+/**
+ * @class FanFRUsWithNonfuncRotorsCause
+ *
+ * This class provides a satisfied() method that checks for
+ * fans with nonfunctional fan rotors in the fan health map.
+ */
+class FanFRUsWithNonfuncRotorsCause : public PowerOffCause
+{
+  public:
+    FanFRUsWithNonfuncRotorsCause() = delete;
+    ~FanFRUsWithNonfuncRotorsCause() = default;
+    FanFRUsWithNonfuncRotorsCause(const FanFRUsWithNonfuncRotorsCause&) =
+        delete;
+    FanFRUsWithNonfuncRotorsCause&
+        operator=(const FanFRUsWithNonfuncRotorsCause&) = delete;
+    FanFRUsWithNonfuncRotorsCause(FanFRUsWithNonfuncRotorsCause&&) = delete;
+    FanFRUsWithNonfuncRotorsCause&
+        operator=(FanFRUsWithNonfuncRotorsCause&&) = delete;
+
+    /**
+     * @brief Constructor
+     *
+     * @param[in] count - The minimum number of fan FRUs with
+     *                    nonfunctional rotors to need a power off.
+     */
+    explicit FanFRUsWithNonfuncRotorsCause(size_t count) :
+        PowerOffCause(count, "Fans with Nonfunctional Rotors")
+    {}
+
+    /**
+     * @brief Returns true if 'count' or more fan FRUs have
+     *        nonfunctional rotors.
+     *
+     * @param[in] fanHealth - The FanHealth map
+     */
+    bool satisfied(const FanHealth& fanHealth) override
+    {
+        size_t count = std::count_if(fanHealth.begin(), fanHealth.end(),
+                                     [](const auto& fan) {
+            const auto& tachs = std::get<sensorFuncHealthPos>(fan.second);
+
+            return std::any_of(tachs.begin(), tachs.end(),
+                               [](bool func) { return !func; });
         });
 
         return count >= _count;

--- a/monitor/test/power_off_cause_test.cpp
+++ b/monitor/test/power_off_cause_test.cpp
@@ -53,3 +53,56 @@ TEST(PowerOffCauseTest, NonfuncRotorTest)
     health["fan2"] = {false, {true, true}};
     EXPECT_FALSE(cause.satisfied(health));
 }
+
+TEST(PowerOffCauseTest, FansWithNonFuncRotorsTest)
+{
+    {
+        FanHealth health{{"fan0", {true, {true, true}}},
+                         {"fan1", {true, {true, true}}},
+                         {"fan2", {true, {true, true}}},
+                         {"fan3", {true, {true, true}}}};
+
+        FanFRUsWithNonfuncRotorsCause cause{2};
+        EXPECT_FALSE(cause.satisfied(health));
+    }
+
+    {
+        FanHealth health{{"fan0", {true, {true, true}}},
+                         {"fan1", {true, {true, true}}},
+                         {"fan2", {true, {false, true}}},
+                         {"fan3", {true, {true, true}}}};
+
+        FanFRUsWithNonfuncRotorsCause cause{2};
+        EXPECT_FALSE(cause.satisfied(health));
+    }
+
+    {
+        FanHealth health{{"fan0", {true, {true, true}}},
+                         {"fan1", {true, {false, false}}},
+                         {"fan2", {true, {true, true}}},
+                         {"fan3", {true, {true, true}}}};
+
+        FanFRUsWithNonfuncRotorsCause cause{2};
+        EXPECT_FALSE(cause.satisfied(health));
+    }
+
+    {
+        FanHealth health{{"fan0", {true, {true, true}}},
+                         {"fan1", {true, {false, false}}},
+                         {"fan2", {true, {true, true}}},
+                         {"fan3", {true, {true, false}}}};
+
+        FanFRUsWithNonfuncRotorsCause cause{2};
+        EXPECT_TRUE(cause.satisfied(health));
+    }
+
+    {
+        FanHealth health{{"fan0", {true, {false, true}}},
+                         {"fan1", {true, {true, true}}},
+                         {"fan2", {true, {true, false}}},
+                         {"fan3", {true, {true, true}}}};
+
+        FanFRUsWithNonfuncRotorsCause cause{2};
+        EXPECT_TRUE(cause.satisfied(health));
+    }
+}


### PR DESCRIPTION
Add a new power off rule  that can count the number of fans with nonfunctional rotors, and then use that with a count of 2 along with a fan missing rule for the Rainier 2U power  off rules.

This means that system will only power off when:
1. One or more fans are missing, or
2. Two or more fans have failing rotors

These commits are both merged upstream.