### PR TITLE
Bonnell Fan Updates

### DIFF
--- a/control/config_files/p10bmc/ibm,bonnell/events.json
+++ b/control/config_files/p10bmc/ibm,bonnell/events.json
@@ -24,7 +24,7 @@
                 "name": "count_state_before_target",
                 "count": 1,
                 "state": false,
-                "target": 18000
+                "target": 17000
             }
         ]
     },
@@ -58,7 +58,7 @@
                 "name": "count_state_before_target",
                 "count": 1,
                 "state": false,
-                "target": 18000
+                "target": 17000
             }
         ]
     },
@@ -140,7 +140,7 @@
                                 "property": { "name": "Value" }
                             }
                         ],
-                        "target": 18000
+                        "target": 17000
                     }
                 ]
             }
@@ -177,7 +177,7 @@
                 "name": "count_state_floor",
                 "count": 1,
                 "state": false,
-                "floor": 18000
+                "floor": 17000
             }
         ]
     },
@@ -251,7 +251,7 @@
                 "count": 1,
                 "state": false,
                 "delay": 5,
-                "floor": 18000
+                "floor": 17000
             }
         ]
     },
@@ -648,11 +648,11 @@
                     "default_value": 10000,
                     "value": [
                         { "arg_value": 500, "parameter_value": 0 },
-                        { "arg_value": 1000, "parameter_value": 700 },
-                        { "arg_value": 1500, "parameter_value": 1600 },
-                        { "arg_value": 2000, "parameter_value": 2300 },
-                        { "arg_value": 2500, "parameter_value": 3200 },
-                        { "arg_value": 3300, "parameter_value": 4000 }
+                        { "arg_value": 1000, "parameter_value": 180 },
+                        { "arg_value": 1500, "parameter_value": 320 },
+                        { "arg_value": 2000, "parameter_value": 650 },
+                        { "arg_value": 2500, "parameter_value": 1010 },
+                        { "arg_value": 3050, "parameter_value": 1370 }
                     ]
                 }
             },
@@ -664,11 +664,11 @@
                     "default_value": 10000,
                     "value": [
                         { "arg_value": 500, "parameter_value": 0 },
-                        { "arg_value": 1000, "parameter_value": 1000 },
-                        { "arg_value": 1500, "parameter_value": 2100 },
-                        { "arg_value": 2000, "parameter_value": 3100 },
-                        { "arg_value": 2500, "parameter_value": 4100 },
-                        { "arg_value": 3300, "parameter_value": 4900 }
+                        { "arg_value": 1000, "parameter_value": 200 },
+                        { "arg_value": 1500, "parameter_value": 340 },
+                        { "arg_value": 2000, "parameter_value": 580 },
+                        { "arg_value": 2500, "parameter_value": 950 },
+                        { "arg_value": 3050, "parameter_value": 1500 }
                     ]
                 }
             },
@@ -680,11 +680,11 @@
                     "default_value": 10000,
                     "value": [
                         { "arg_value": 500, "parameter_value": 0 },
-                        { "arg_value": 1000, "parameter_value": 1000 },
-                        { "arg_value": 1500, "parameter_value": 2100 },
-                        { "arg_value": 2000, "parameter_value": 3200 },
-                        { "arg_value": 2500, "parameter_value": 4000 },
-                        { "arg_value": 3300, "parameter_value": 4800 }
+                        { "arg_value": 1000, "parameter_value": 250 },
+                        { "arg_value": 1500, "parameter_value": 580 },
+                        { "arg_value": 2000, "parameter_value": 980 },
+                        { "arg_value": 2500, "parameter_value": 1430 },
+                        { "arg_value": 3050, "parameter_value": 1930 }
                     ]
                 }
             },
@@ -696,11 +696,11 @@
                     "default_value": 10000,
                     "value": [
                         { "arg_value": 500, "parameter_value": 0 },
-                        { "arg_value": 1000, "parameter_value": 900 },
-                        { "arg_value": 1500, "parameter_value": 1700 },
-                        { "arg_value": 2000, "parameter_value": 2500 },
-                        { "arg_value": 2500, "parameter_value": 3400 },
-                        { "arg_value": 3300, "parameter_value": 4200 }
+                        { "arg_value": 1000, "parameter_value": 340 },
+                        { "arg_value": 1500, "parameter_value": 720 },
+                        { "arg_value": 2000, "parameter_value": 1180 },
+                        { "arg_value": 2500, "parameter_value": 1800 },
+                        { "arg_value": 3050, "parameter_value": 2550 }
                     ]
                 }
             },
@@ -712,11 +712,11 @@
                     "default_value": 10000,
                     "value": [
                         { "arg_value": 500, "parameter_value": 0 },
-                        { "arg_value": 1000, "parameter_value": 1000 },
-                        { "arg_value": 1500, "parameter_value": 1900 },
-                        { "arg_value": 2000, "parameter_value": 2800 },
-                        { "arg_value": 2500, "parameter_value": 3700 },
-                        { "arg_value": 3300, "parameter_value": 4500 }
+                        { "arg_value": 1000, "parameter_value": 450 },
+                        { "arg_value": 1500, "parameter_value": 1050 },
+                        { "arg_value": 2000, "parameter_value": 1820 },
+                        { "arg_value": 2500, "parameter_value": 2590 },
+                        { "arg_value": 3050, "parameter_value": 3360 }
                     ]
                 }
             }
@@ -777,17 +777,17 @@
                     {
                         // Entry valid for temps < 20
                         "key": 20,
-                        "default_floor": 5400,
+                        "default_floor": 4130,
                         "floor_offset_parameter": "ambient_20_altitude_offset",
                         "floors": [
                             {
                                 "parameter": "pcie_floor_index",
                                 "floors": [
-                                    { "value": 1, "floor": 5600 },
-                                    { "value": 2, "floor": 9000 },
-                                    { "value": 3, "floor": 9000 },
-                                    { "value": 4, "floor": 9200 },
-                                    { "value": 5, "floor": 10600 }
+                                    { "value": 1, "floor": 5130 },
+                                    { "value": 2, "floor": 6130 },
+                                    { "value": 3, "floor": 7130 },
+                                    { "value": 4, "floor": 8130 },
+                                    { "value": 5, "floor": 9130 }
                                 ]
                             }
                         ]
@@ -795,17 +795,17 @@
                     {
                         // Entry valid for temps < 25
                         "key": 25,
-                        "default_floor": 6500,
+                        "default_floor": 4810,
                         "floor_offset_parameter": "ambient_25_altitude_offset",
                         "floors": [
                             {
                                 "parameter": "pcie_floor_index",
                                 "floors": [
-                                    { "value": 1, "floor": 7800 },
-                                    { "value": 2, "floor": 10700 },
-                                    { "value": 3, "floor": 11300 },
-                                    { "value": 4, "floor": 12700 },
-                                    { "value": 5, "floor": 13900 }
+                                    { "value": 1, "floor": 5810 },
+                                    { "value": 2, "floor": 6810 },
+                                    { "value": 3, "floor": 7810 },
+                                    { "value": 4, "floor": 8810 },
+                                    { "value": 5, "floor": 9810 }
                                 ]
                             }
                         ]
@@ -813,17 +813,17 @@
                     {
                         // Entry valid for temps < 30
                         "key": 30,
-                        "default_floor": 6500,
+                        "default_floor": 5930,
                         "floor_offset_parameter": "ambient_30_altitude_offset",
                         "floors": [
                             {
                                 "parameter": "pcie_floor_index",
                                 "floors": [
-                                    { "value": 1, "floor": 10300 },
-                                    { "value": 2, "floor": 12100 },
-                                    { "value": 3, "floor": 14400 },
-                                    { "value": 4, "floor": 16300 },
-                                    { "value": 5, "floor": 17200 }
+                                    { "value": 1, "floor": 6930 },
+                                    { "value": 2, "floor": 7930 },
+                                    { "value": 3, "floor": 8930 },
+                                    { "value": 4, "floor": 9930 },
+                                    { "value": 5, "floor": 10930 }
                                 ]
                             }
                         ]
@@ -831,17 +831,17 @@
                     {
                         // Entry valid for temps < 35
                         "key": 35,
-                        "default_floor": 8500,
+                        "default_floor": 7940,
                         "floor_offset_parameter": "ambient_35_altitude_offset",
                         "floors": [
                             {
                                 "parameter": "pcie_floor_index",
                                 "floors": [
-                                    { "value": 1, "floor": 12700 },
-                                    { "value": 2, "floor": 13500 },
-                                    { "value": 3, "floor": 17400 },
-                                    { "value": 4, "floor": 18000 },
-                                    { "value": 5, "floor": 18000 }
+                                    { "value": 1, "floor": 8940 },
+                                    { "value": 2, "floor": 9940 },
+                                    { "value": 3, "floor": 10940 },
+                                    { "value": 4, "floor": 11940 },
+                                    { "value": 5, "floor": 12940 }
                                 ]
                             }
                         ]
@@ -849,17 +849,17 @@
                     {
                         // Entry valid for temps < 40
                         "key": 40,
-                        "default_floor": 12600,
+                        "default_floor": 10670,
                         "floor_offset_parameter": "ambient_40_altitude_offset",
                         "floors": [
                             {
                                 "parameter": "pcie_floor_index",
                                 "floors": [
-                                    { "value": 1, "floor": 15000 },
-                                    { "value": 2, "floor": 15500 },
-                                    { "value": 3, "floor": 18000 },
-                                    { "value": 4, "floor": 18000 },
-                                    { "value": 5, "floor": 18000 }
+                                    { "value": 1, "floor": 11670 },
+                                    { "value": 2, "floor": 12670 },
+                                    { "value": 3, "floor": 13670 },
+                                    { "value": 4, "floor": 14670 },
+                                    { "value": 5, "floor": 15670 }
                                 ]
                             }
                         ]

--- a/control/config_files/p10bmc/ibm,bonnell/pcie_cards.json
+++ b/control/config_files/p10bmc/ibm,bonnell/pcie_cards.json
@@ -9,143 +9,47 @@
             "floor_index": 5
         },
         {
-            "name": "Flett",
-            "vendor_id": "0x1014",
-            "device_id": "0x04F2",
-            "subsystem_vendor_id": "0x1014",
-            "subsystem_id": "0x0007",
-            "has_temp_sensor": true
-        },
-        {
-            "name": "Bear Lake and Bear River",
-            "vendor_id": "0x1014",
-            "device_id": "0x04F2",
-            "subsystem_vendor_id": "0x1014",
-            "subsystem_id": "0x0004",
-            "has_temp_sensor": true
-        },
-        {
-            "name": "Everglades 10Gb 2Port",
+            "name": "Manatee LP",
             "vendor_id": "0x15B3",
-            "device_id": "0x1015",
+            "device_id": "0x101F",
             "subsystem_vendor_id": "0x1014",
-            "subsystem_id": "0x061F",
+            "subsystem_id": "0x06AA",
             "floor_index": 1
         },
         {
-            "name": "Everglades 25Gb 2Port",
+            "name": "Manatee - Crypto LP",
             "vendor_id": "0x15B3",
-            "device_id": "0x1015",
+            "device_id": "0x101F",
             "subsystem_vendor_id": "0x1014",
-            "subsystem_id": "0x061E",
+            "subsystem_id": "0x06AB",
             "floor_index": 1
         },
         {
-            "name": "Cedar Lake 100G 2port",
-            "vendor_id": "0x15B3",
-            "device_id": "0x101D",
+            "name": "Mayo - LP",
+            "vendor_id": "0x14E4",
+            "device_id": "0x1657",
             "subsystem_vendor_id": "0x1014",
-            "subsystem_id": "0x06A6",
-            "floor_index": 5
-        },
-        {
-            "name": "Cedar Lake Crypto 100G 2port",
-            "vendor_id": "0x15B3",
-            "device_id": "0x101D",
-            "subsystem_vendor_id": "0x1014",
-            "subsystem_id": "0x06A5",
-            "floor_index": 5
-        },
-        {
-            "name": "GTO",
-            "vendor_id": "0x1014",
-            "device_id": "0x034A",
-            "subsystem_vendor_id": "0x1014",
-            "subsystem_id": "0x033B",
-            "floor_index": 3
-        },
-        {
-            "name": "Bolt PCIe3 NVMe Flash Adapter II x8 1.6TB",
-            "vendor_id": "0x144D",
-            "device_id": "0xA822",
-            "subsystem_vendor_id": "0x1014",
-            "subsystem_id": "0x0621",
-            "floor_index": 3
-        },
-        {
-            "name": "Bolt PCIe3 NVMe Flash Adapter II x8 3.2TB",
-            "vendor_id": "0x144D",
-            "device_id": "0xA822",
-            "subsystem_vendor_id": "0x1014",
-            "subsystem_id": "0x0622",
-            "floor_index": 4
-        },
-        {
-            "name": "Bolt PCIe3 NVMe Flash Adapter II x8 6.4TB",
-            "vendor_id": "0x144D",
-            "device_id": "0xA822",
-            "subsystem_vendor_id": "0x1014",
-            "subsystem_id": "0x0629",
-            "floor_index": 4
-        },
-        {
-            "name": "Bolt PCIe3 NVMe Flash Adapter III x8 1.6TB",
-            "vendor_id": "0x144D",
-            "device_id": "0xA822",
-            "subsystem_vendor_id": "0x1014",
-            "subsystem_id": "0x064A",
-            "floor_index": 3
-        },
-        {
-            "name": "Bolt PCIe3 NVMe Flash Adapter III x8 3.2TB",
-            "vendor_id": "0x144D",
-            "device_id": "0xA822",
-            "subsystem_vendor_id": "0x1014",
-            "subsystem_id": "0x064B",
-            "floor_index": 4
-        },
-        {
-            "name": "Bolt PCIe3 NVMe Flash Adapter III x8 6.4TB",
-            "vendor_id": "0x144D",
-            "device_id": "0xA822",
-            "subsystem_vendor_id": "0x1014",
-            "subsystem_id": "0x064C",
-            "floor_index": 4
-        },
-        {
-            "name": "Kona PCIe4 NVMe U.2 Flash Adapter x8 1.6TB",
-            "vendor_id": "0x144D",
-            "device_id": "0xA824",
-            "subsystem_vendor_id": "0x1014",
-            "subsystem_id": "0x0682",
-            "floor_index": 4
-        },
-        {
-            "name": "Kona PCIe4 NVMe U.2 Flash Adapter x8 3.2TB",
-            "vendor_id": "0x144D",
-            "device_id": "0xA824",
-            "subsystem_vendor_id": "0x1014",
-            "subsystem_id": "0x0683",
-            "floor_index": 4
-        },
-        {
-            "name": "Kona PCIe4 NVMe U.2 Flash Adapter x8 6.4TB",
-            "vendor_id": "0x144D",
-            "device_id": "0xA824",
-            "subsystem_vendor_id": "0x1014",
-            "subsystem_id": "0x0684",
-            "floor_index": 4
-        },
-        {
-            "name": "Puntfish",
-            "vendor_id": "0x1077",
-            "device_id": "0x2271",
-            "subsystem_vendor_id": "0x1014",
-            "subsystem_id": "0x069E",
+            "subsystem_id": "0x0719",
             "floor_index": 1
         },
         {
-            "name": "Flavafish",
+            "name": "Shasta - LP",
+            "vendor_id": "0x8086",
+            "device_id": "0x15FF",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x0002/0x0000",
+            "floor_index": 1
+        },
+        {
+            "name": "Austin - LP",
+            "vendor_id": "0x14E4",
+            "device_id": "0x1657",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x0420",
+            "floor_index": 1
+        },
+        {
+            "name": "Flavafish - LP",
             "vendor_id": "0x1077",
             "device_id": "0x2281",
             "subsystem_vendor_id": "0x1014",
@@ -153,36 +57,28 @@
             "floor_index": 1
         },
         {
-            "name": "Haleakala EN 2Port 100Gb",
-            "vendor_id": "0x15B3",
-            "device_id": "0x1019",
+            "name": "BlueFin2 - LP",
+            "vendor_id": "0x10DF",
+            "device_id": "0xE300",
             "subsystem_vendor_id": "0x1014",
-            "subsystem_id": "0x0635",
-            "floor_index": 5
+            "subsystem_id": "0x06A0",
+            "floor_index": 1
         },
         {
-            "name": "Crater Lake Crypto 200G 2Port",
-            "vendor_id": "0x15B3",
-            "device_id": "0x101D",
+            "name": "Redfish - LP",
+            "vendor_id": "0x10DF",
+            "device_id": "0xE300",
             "subsystem_vendor_id": "0x1014",
-            "subsystem_id": "0x06A3",
-            "floor_index": 5
+            "subsystem_id": "0x0615",
+            "floor_index": 1
         },
         {
-            "name": "Crater Lake 200G 2Port",
-            "vendor_id": "0x15B3",
-            "device_id": "0x101D",
+            "name": "Pinto - LP",
+            "vendor_id": "0x11F8",
+            "device_id": "0x8072",
             "subsystem_vendor_id": "0x1014",
-            "subsystem_id": "0x06A4",
-            "floor_index": 5
-        },
-        {
-            "name": "Lassen 2 Port IB",
-            "vendor_id": "0x15B3",
-            "device_id": "0x1019",
-            "subsystem_vendor_id": "0x1014",
-            "subsystem_id": "0x0617",
-            "floor_index": 5
+            "subsystem_id": "0x06F0",
+            "floor_index": 1
         }
     ]
 }

--- a/control/config_files/p10bmc/ibm,rainier-2u/zones.json
+++ b/control/config_files/p10bmc/ibm,rainier-2u/zones.json
@@ -1,8 +1,8 @@
 [
     {
         "name": "0",
-        "poweron_target": 18000,
-        "default_floor": 18000,
+        "poweron_target": 17000,
+        "default_floor": 17000,
         "increase_delay": 5,
         "decrease_interval": 30
     }

--- a/monitor/config_files/p10bmc/ibm,bonnell/config.json
+++ b/monitor/config_files/p10bmc/ibm,bonnell/config.json
@@ -21,8 +21,8 @@
                     "name": "fan0_1",
                     "threshold": 30,
                     "has_target": false,
-                    "factor": 0.625,
-                    "offset": 1100
+                    "factor": 0.685,
+                    "offset": 700
                 }
             ]
         },
@@ -47,8 +47,8 @@
                     "name": "fan1_1",
                     "threshold": 30,
                     "has_target": false,
-                    "factor": 0.625,
-                    "offset": 1100
+                    "factor": 0.685,
+                    "offset": 700
                 }
             ]
         }


### PR DESCRIPTION
These two commits should be the final updates for Bonnell fan control and monitoring.

They were both merged upstream:
https://gerrit.openbmc.org/c/openbmc/phosphor-fan-presence/+/70578
https://gerrit.openbmc.org/c/openbmc/phosphor-fan-presence/+/70579

One updates the equation for the outlet fan rotor to work for multiple types of fans.
The other changes the max RPM to 17000, and provides the final floor table and hot PCIe card list.
