### PR TITLE
control:configs: Fix bonnell/rainier2U zones.json

### DIFF
--- a/control/config_files/p10bmc/ibm,bonnell/zones.json
+++ b/control/config_files/p10bmc/ibm,bonnell/zones.json
@@ -1,8 +1,8 @@
 [
     {
         "name": "0",
-        "poweron_target": 18000,
-        "default_floor": 18000,
+        "poweron_target": 17000,
+        "default_floor": 17000,
         "increase_delay": 5,
         "decrease_interval": 30
     }

--- a/control/config_files/p10bmc/ibm,rainier-2u/zones.json
+++ b/control/config_files/p10bmc/ibm,rainier-2u/zones.json
@@ -1,8 +1,8 @@
 [
     {
         "name": "0",
-        "poweron_target": 17000,
-        "default_floor": 17000,
+        "poweron_target": 18000,
+        "default_floor": 18000,
         "increase_delay": 5,
         "decrease_interval": 30
     }


### PR DESCRIPTION
A previous commit attempted to change the poweron_target and default_floor values for bonnell to 17000, but it changed them for rainier 2U instead. Do it the right way this time.


Change-Id: I579cf8197f4a7b012056265f3f6309f915cdf1de