### PR TITLE
1060:CI-only: create detect-secrets baseline file

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,140 @@
+{
+  "exclude": {
+    "files": "^.secrets.baseline$",
+    "lines": null
+  },
+  "generated_at": "2024-04-26T19:28:52Z",
+  "plugins_used": [
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "base64_limit": 4.5,
+      "name": "Base64HighEntropyString"
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "BoxDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "ghe_instance": "github.ibm.com",
+      "name": "GheDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "hex_limit": 3,
+      "name": "HexHighEntropyString"
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "keyword_exclude": null,
+      "name": "KeywordDetector"
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "results": {
+    "control/config_files/p10bmc/ibm,rainier-1s4u/groups.json": [
+      {
+        "hashed_secret": "ccabe1069f631b1fd47176e139d94f100dd468af",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 365,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "93fde654a0fc8800f49cd467ce02d38d3ad59b91",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 366,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "control/config_files/p10bmc/ibm,rainier-2u/groups.json": [
+      {
+        "hashed_secret": "ccabe1069f631b1fd47176e139d94f100dd468af",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 563,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "93fde654a0fc8800f49cd467ce02d38d3ad59b91",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 564,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "control/config_files/p10bmc/ibm,rainier-4u/groups.json": [
+      {
+        "hashed_secret": "ccabe1069f631b1fd47176e139d94f100dd468af",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 575,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "93fde654a0fc8800f49cd467ce02d38d3ad59b91",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 576,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ]
+  },
+  "version": "0.13.1+ibm.62.dss",
+  "word_list": {
+    "file": null,
+    "hash": null
+  }
+}


### PR DESCRIPTION
This creates a baseline file (and initial responses to any potential secrets found).

After this file is merged, all CI jobs after will run the detect-secrets tool against incoming commits to verify no potential secrets are being shared. If one is found, CI will fail until the .secrets.baseline is updated for the new issue.

See the following for more info:
  https://github.com/IBM/detect-secrets