### PR TITLE
control:ibm,Bonnell: Add hot PCIe card

### DIFF
--- a/control/config_files/p10bmc/ibm,bonnell/events.json
+++ b/control/config_files/p10bmc/ibm,bonnell/events.json
@@ -782,7 +782,7 @@
                         "floors": [
                             {
                                 "parameter": "pcie_floor_index",
-                                "floors": []
+                                "floors": [{ "value": 1, "floor": 6200 }]
                             }
                         ]
                     },
@@ -794,7 +794,7 @@
                         "floors": [
                             {
                                 "parameter": "pcie_floor_index",
-                                "floors": []
+                                "floors": [{ "value": 1, "floor": 6800 }]
                             }
                         ]
                     },
@@ -806,7 +806,7 @@
                         "floors": [
                             {
                                 "parameter": "pcie_floor_index",
-                                "floors": []
+                                "floors": [{ "value": 1, "floor": 7400 }]
                             }
                         ]
                     },
@@ -818,7 +818,7 @@
                         "floors": [
                             {
                                 "parameter": "pcie_floor_index",
-                                "floors": []
+                                "floors": [{ "value": 1, "floor": 8500 }]
                             }
                         ]
                     },
@@ -830,7 +830,7 @@
                         "floors": [
                             {
                                 "parameter": "pcie_floor_index",
-                                "floors": []
+                                "floors": [{ "value": 1, "floor": 9800 }]
                             }
                         ]
                     }

--- a/control/config_files/p10bmc/ibm,bonnell/pcie_cards.json
+++ b/control/config_files/p10bmc/ibm,bonnell/pcie_cards.json
@@ -1,3 +1,12 @@
 {
-    "cards": []
+    "cards": [
+        {
+            "name": "GTO",
+            "vendor_id": "0x1014",
+            "device_id": "0x034A",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x033B",
+            "floor_index": 1
+        }
+    ]
 }

--- a/docs/control/events.md
+++ b/docs/control/events.md
@@ -645,10 +645,10 @@ from maximum group property value. The mapping is based on a provided table. If
 there are more than one event using this action, the maximum speed derived from
 the mapping of all groups will be set to the zone's target.
 
-... { "name": "target_from_group_max", "groups": [ { "name": "zone0_ambient",
-"interface": "xyz.openbmc_project.Sensor.Value", "property": { "name": "Value" }
-} ], "neg_hysteresis": 1, "pos_hysteresis": 0, "map": [ { "value": 10.0,
-"target": 38.0 }, ... ] }
+... { "name": "target_from_group_max", "groups": [ { "name":
+"zone0_ambient", "interface": "xyz.openbmc_project.Sensor.Value", "property":
+{ "name": "Value" } } ], "neg_hysteresis": 1, "pos_hysteresis": 0, "map": [
+{ "value": 10.0, "target": 38.0 }, ... ] }
 
 The above JSON will cause the action to read the property specified in the group
 "zone0_ambient" from all members of the group. The change in the group's members

--- a/hwmon_ffdc.cpp
+++ b/hwmon_ffdc.cpp
@@ -22,8 +22,10 @@ inline std::vector<std::string> executeCommand(const std::string& command)
     std::vector<std::string> output;
     std::array<char, 128> buffer;
 
-    std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(command.c_str(), "r"),
-                                                  pclose);
+    auto closer = [](FILE* fp) { pclose(fp); };
+
+    std::unique_ptr<FILE, decltype(closer)> pipe(popen(command.c_str(), "r"),
+                                                 closer);
     if (!pipe)
     {
         getLogger().log(


### PR DESCRIPTION
Add the 'GTO' PCIe card to the list of hot PCIe cards, and add floor values for its floor index.


Change-Id: Ie2863a08cdf9c85ca5e6c25d56d4cc367da60218