### PR TITLE
control: Periodically write out target values

### DIFF
--- a/control/json/manager.hpp
+++ b/control/json/manager.hpp
@@ -637,6 +637,12 @@ class Manager
     std::map<configKey, std::unique_ptr<Event>> _events;
 
     /**
+     * @brief Timer used to periodically flush the current fan target out
+     *        to the hardware.
+     */
+    sdeventplus::utility::Timer<sdeventplus::ClockId::Monotonic> _flushTimer;
+
+    /**
      * @brief A map of parameter names and values that are something
      *        other than just D-Bus property values that other actions
      *        can set and use.
@@ -706,6 +712,12 @@ class Manager
      * @param[in] groups - The groups to add
      */
     void addGroups(const std::vector<Group>& groups);
+
+    /**
+     * @brief Writes the current fan targets to the hardware because
+     *        the fan controller can reset and lose its values.
+     */
+    void flushTargets();
 };
 
 } // namespace phosphor::fan::control::json


### PR DESCRIPTION
Fan control doesn't write the fan targets unless they change, which may not be very often.

However, the MAX31785 fan control chip may reset itself due to an internal problem and set the fan speed registers back to whatever they were when the config regs were last saved via the 'STORE_DEFAULT_ALL' cmd.  At that point, the chip wouldn't match what's in /sys/class/hwmon nor on D-Bus, and fan monitor sees that as fan faults.

To fix that, fan control will periodically write out the current fan target to the hardware, so that if the hardware loses its values it will shortly be corrected.


Change-Id: I5116692d864eb74b20edcdc356c77d3ff4880586