### PR TITLE
monitor: Fan controller malfunction monitoring

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -53,6 +53,8 @@ sdbusplus_dep = dependency('sdbusplus')
 sdeventplus_dep = dependency('sdeventplus')
 stdplus_dep = dependency('stdplus')
 systemd_dep = dependency('systemd')
+libgpiodcxx_dep = dependency('libgpiodcxx',
+    default_options: ['bindings=cxx'])
 
 if(get_option('tests').allowed())
     gmock_dep = dependency('gmock', disabler: true, required: false)

--- a/monitor/fan.hpp
+++ b/monitor/fan.hpp
@@ -201,6 +201,11 @@ class Fan
      */
     bool outOfRange(const TachSensor& sensor);
 
+    /**
+     * @brief Prepares for a fan controller reset
+     */
+    void prepForCtlrReset();
+
   private:
     /**
      * @brief Returns the number sensors that are nonfunctional

--- a/monitor/fan_error.cpp
+++ b/monitor/fan_error.cpp
@@ -136,6 +136,13 @@ std::map<std::string, std::string>
     if (!_fanName.empty())
     {
         ad.emplace("CALLOUT_INVENTORY_PATH", _fanName);
+
+        // Set a hint to not use the default high priority
+        // if necessary.
+        if (_fanCalloutPriority == FanCalloutPriority::low)
+        {
+            ad.emplace("CALLOUT_PRIORITY", "L");
+        }
     }
 
     if (!_sensorName.empty())

--- a/monitor/fan_error.hpp
+++ b/monitor/fan_error.hpp
@@ -76,6 +76,12 @@ class FFDCFile
 class FanError
 {
   public:
+    enum class FanCalloutPriority
+    {
+        low,
+        high
+    };
+
     FanError() = delete;
     ~FanError() = default;
     FanError(const FanError&) = delete;
@@ -92,15 +98,18 @@ class FanError
      * @param[in] sensor - The failing sensor's inventory path.  Can be empty
      *                     if the error is for the FRU and not the sensor.
      * @param[in] severity - The severity of the error
+     * @param[in] fanCalloutPriority - Callout priority to use for the fan
      */
-    FanError(const std::string& error, const std::string& fan,
-             const std::string& sensor,
-             sdbusplus::xyz::openbmc_project::Logging::server::Entry::Level
-                 severity) :
+    FanError(
+        const std::string& error, const std::string& fan,
+        const std::string& sensor,
+        sdbusplus::xyz::openbmc_project::Logging::server::Entry::Level severity,
+        FanCalloutPriority fanCalloutPriority = FanCalloutPriority::high) :
         _errorName(error), _fanName(fan), _sensorName(sensor),
         _severity(
             sdbusplus::xyz::openbmc_project::Logging::server::convertForMessage(
-                severity))
+                severity)),
+        _fanCalloutPriority(fanCalloutPriority)
     {}
 
     /**
@@ -118,7 +127,8 @@ class FanError
         _errorName(error),
         _severity(
             sdbusplus::xyz::openbmc_project::Logging::server::convertForMessage(
-                severity))
+                severity)),
+        _fanCalloutPriority(FanCalloutPriority::high)
     {}
 
     /**
@@ -211,6 +221,11 @@ class FanError
      *        representation of the Entry::Level property.
      */
     const std::string _severity;
+
+    /**
+     * @brief Priority to use for the fan callout
+     */
+    FanCalloutPriority _fanCalloutPriority;
 };
 
 } // namespace phosphor::fan::monitor

--- a/monitor/json_parser.cpp
+++ b/monitor/json_parser.cpp
@@ -563,4 +563,24 @@ std::optional<size_t> getNumNonfuncRotorsBeforeError(const json& obj)
     return num;
 }
 
+std::optional<std::tuple<std::string, size_t>>
+    getMalfunctionMonitorData(const json& obj)
+{
+    auto section = obj.find("runaway_tach_malfunction_handling");
+
+    if (section != obj.end())
+    {
+        if (!section->contains("gpio") || !section->contains("tach_limit"))
+        {
+            throw std::runtime_error(
+                "Missing 'gpio' or 'tach_limit' in "
+                "runaway_tach_malfunction_handling JSON section");
+        }
+
+        return std::tuple{section->at("gpio").get<std::string>(),
+                          section->at("tach_limit").get<size_t>()};
+    }
+    return std::nullopt;
+}
+
 } // namespace phosphor::fan::monitor

--- a/monitor/json_parser.hpp
+++ b/monitor/json_parser.hpp
@@ -105,4 +105,14 @@ std::vector<std::unique_ptr<PowerOffRule>> getPowerOffRules(
  */
 std::optional<size_t> getNumNonfuncRotorsBeforeError(const json& obj);
 
+/**
+ * @brief Returns the fan controller malfunction recovery fields
+ *
+ * @param[in] obj - JSON object to parse from
+ *
+ * @return optional<tuple> - The GPIO name and tach limit if present.
+ */
+std::optional<std::tuple<std::string, size_t>>
+    getMalfunctionMonitorData(const json& obj);
+
 } // namespace phosphor::fan::monitor

--- a/monitor/malfunction_monitor.cpp
+++ b/monitor/malfunction_monitor.cpp
@@ -1,0 +1,97 @@
+#include "malfunction_monitor.hpp"
+
+#include "logging.hpp"
+#include "system.hpp"
+
+#include <gpiod.hpp>
+
+namespace phosphor::fan::monitor
+{
+
+MalfunctionMonitor::MalfunctionMonitor(System& system, double limit,
+                                       std::string_view resetGPIO) :
+    system(system), tachLimit(limit), resetGPIO(resetGPIO)
+{}
+
+bool MalfunctionMonitor::checkAndAttemptRecovery(const TachSensor& sensor)
+{
+    if (!malfunctionDetected(sensor))
+    {
+        return false;
+    }
+
+    if (!affectedFans.contains(sensor.getFan().getName()))
+    {
+        // Don't proceed if a new sensor is caught but the power state is
+        // off since the chip can emit false positives right when power is
+        // being cut.  If it's on a fan already in affectedFans, then we'll
+        // have already done the reset and won't do another one anyway.
+        // The PowerState class in System isn't fast enough to catch this
+        // since PGood is still up.
+        if (!system.isPowerStateOn())
+        {
+            return false;
+        }
+
+        affectedFans.insert(sensor.getFan().getName());
+    }
+
+    if (resetDone)
+    {
+        return false;
+    }
+
+    getLogger().log(
+        std::format("FanCtlr malfunction detected. Tach {} value {} "
+                    "is over limit.",
+                    sensor.name(), sensor.getInput()),
+        Logger::Priority::error);
+
+    system.prepForCtlrReset();
+    resetFanController();
+    logResetError(sensor);
+    resetDone = true;
+
+    return true;
+}
+
+void MalfunctionMonitor::resetFanController()
+{
+    getLogger().log("Resetting fan controller to recover",
+                    Logger::Priority::error);
+    try
+    {
+        using namespace std::chrono_literals;
+
+        auto line = gpiod::find_line(resetGPIO);
+
+        gpiod::line_request config{__FUNCTION__,
+                                   gpiod::line_request::DIRECTION_OUTPUT, 0};
+        line.request(config);
+        line.set_value(0);
+        std::this_thread::sleep_for(10ms);
+        line.set_value(1);
+        line.release();
+    }
+    catch (const std::exception& e)
+    {
+        getLogger().log(
+            std::format("GPIO error while resetting fan controller: {}",
+                        e.what()),
+            Logger::Priority::error);
+    }
+}
+
+void MalfunctionMonitor::logResetError(const TachSensor& sensor) const
+{
+    using Severity =
+        sdbusplus::xyz::openbmc_project::Logging::server::Entry::Level;
+
+    FanError error{"xyz.openbmc_project.Fan.Error.CtlrReset", "", sensor.name(),
+                   Severity::Informational};
+
+    auto sensorData = system.captureSensorData();
+    error.commit(sensorData);
+}
+
+} // namespace phosphor::fan::monitor

--- a/monitor/malfunction_monitor.hpp
+++ b/monitor/malfunction_monitor.hpp
@@ -1,0 +1,135 @@
+#pragma once
+
+#include "tach_sensor.hpp"
+
+#include <chrono>
+#include <unordered_set>
+
+namespace phosphor::fan::monitor
+{
+
+class System;
+
+/**
+ * @class MalfunctionMonitor
+ *
+ * This class attempts to fix a max31785 fan controller malfunction
+ * where it mysteriously emits unrealistically high tach readings.
+ *
+ * Typically in the field the previous captured readings have
+ * alternated between exactly 29104 and zero.
+ *
+ * It will trigger on a high tach reading, specified in a JSON
+ * config, and will then reset the fan controller with the specified
+ * GPIO to try to recover.
+ *
+ * It won't allow another reset until resetState() is called.
+ */
+class MalfunctionMonitor
+{
+  public:
+    MalfunctionMonitor() = delete;
+    ~MalfunctionMonitor() = default;
+    MalfunctionMonitor(const MalfunctionMonitor&) = delete;
+    MalfunctionMonitor& operator=(const MalfunctionMonitor&) = delete;
+    MalfunctionMonitor(MalfunctionMonitor&&) = delete;
+    MalfunctionMonitor& operator=(MalfunctionMonitor&&) = delete;
+
+    /**
+     * @brief Constructor
+     *
+     * @param[in] system - The System object
+     * @param[in] limit - The max tach limit to identify the malfunction
+     * @param[in] resetGPIO - gpiod GPIO name to do the reset
+     */
+    MalfunctionMonitor(System& system, double limit,
+                       std::string_view resetGPIO);
+
+    /**
+     * @brief Checks if the sensor's tach reading is showing evidence of a
+     *        malfunction and attempts to recover from it by resetting the
+     *        fan controller, if a reset hasn't already been done.
+     *
+     * @param[in] sensor - The sensor to check
+     *
+     * @return bool - true if malfunction detected and reset done, false else
+     */
+    bool checkAndAttemptRecovery(const TachSensor& sensor);
+
+    /**
+     * @brief Checks if a sensor on the fan specified has shown evidence
+     *        of a malfunction.
+     *
+     * @param[in] fanName - the name of the fan to check
+     *
+     * @return bool - true if the fan is affected, false else
+     */
+    bool isFanAffected(const std::string& fanName) const
+    {
+        return affectedFans.contains(fanName);
+    }
+
+    /**
+     * @brief Resets the object back to a no malfunction state.
+     */
+    inline void resetState()
+    {
+        resetDone = false;
+        affectedFans.clear();
+    }
+
+  private:
+    /**
+     * @brief Resets the fan control device by toggling a GPIO
+     */
+    void resetFanController();
+
+    /**
+     * @brief Says if the malfunction is detected on the sensor
+     *
+     * @param[in] sensor - The sensor to check
+     *
+     * @return bool - true if detected, false else
+     */
+    inline bool malfunctionDetected(const TachSensor& sensor) const
+    {
+        return sensor.getInput() >= tachLimit;
+    }
+
+    /**
+     * @brief Creates an informational event log stating that the
+     *       reset occurred.
+     *
+     * @param[in] sensor - The sensor first detecting the malfunction
+     *                     leading to the reset.
+     */
+    void logResetError(const TachSensor& sensor) const;
+
+    /**
+     * @brief Reference to the System object
+     */
+    System& system;
+
+    /**
+     * @brief The tach limit used to identify the malfunction
+     */
+    double tachLimit;
+
+    /**
+     * @brief The GPIO to use to do the reset
+     */
+    std::string resetGPIO;
+
+    /**
+     * @brief A list of all fans affected by the malfunction in the current
+     *        reset period.
+     */
+    std::unordered_set<std::string> affectedFans;
+
+    /**
+     * @brief If a reset was already done this power on.
+     */
+    bool resetDone = false;
+};
+
+} // namespace phosphor::fan::monitor

--- a/monitor/meson.build
+++ b/monitor/meson.build
@@ -10,6 +10,7 @@ sources=[
     'json_parser.cpp',
     'logging.cpp',
     'main.cpp',
+    'malfunction_monitor.cpp',
     'power_interface.cpp',
     'system.cpp',
     'tach_sensor.cpp',
@@ -21,7 +22,8 @@ deps=[
     phosphor_dbus_interfaces_dep,
     phosphor_logging_dep,
     sdbusplus_dep,
-    sdeventplus_dep
+    sdeventplus_dep,
+    libgpiodcxx_dep,
 ]
 
 # Only needed for YAML config

--- a/monitor/system.cpp
+++ b/monitor/system.cpp
@@ -103,6 +103,7 @@ void System::load()
         // Retrieve fan definitions and create fan objects to be monitored
         setFans(fanDefs);
         setFaultConfig(jsonObj);
+        setMalfunctionMonitor(jsonObj);
         log<level::INFO>("Configuration loaded");
 
         _loaded = true;
@@ -360,6 +361,19 @@ void System::setFaultConfig([[maybe_unused]] const json& jsonObj)
 #endif
 }
 
+void System::setMalfunctionMonitor([[maybe_unused]] const json& jsonObj)
+{
+#ifdef MONITOR_USE_JSON
+    auto params = getMalfunctionMonitorData(jsonObj);
+    if (params)
+    {
+        malfunctionMonitor = std::make_unique<MalfunctionMonitor>(
+            *this, std::get<size_t>(params.value()),
+            std::get<std::string>(params.value()));
+    }
+#endif
+}
+
 void System::powerStateChanged(bool powerStateOn)
 {
     std::for_each(_fans.begin(), _fans.end(), [powerStateOn](auto& fan) {
@@ -420,25 +434,42 @@ void System::powerStateChanged(bool powerStateOn)
         // Cancel any in-progress power off actions
         std::for_each(_powerOffRules.begin(), _powerOffRules.end(),
                       [this](auto& rule) { rule->cancel(); });
+
+        if (malfunctionMonitor)
+        {
+            malfunctionMonitor->resetState();
+        }
     }
 }
 
 void System::sensorErrorTimerExpired(const Fan& fan, const TachSensor& sensor)
 {
     std::string fanPath{util::INVENTORY_PATH + fan.getName()};
+    auto malfunctioning = isMalfunctioning(fan);
 
-    getLogger().log(
-        std::format("Creating event log for faulted fan {} sensor {}", fanPath,
-                    sensor.name()),
-        Logger::error);
+    if (malfunctioning)
+    {
+        getLogger().log(
+            std::format(
+                "Creating event log for malfunctioning fan ctlr and sensor {}",
+                sensor.name()),
+            Logger::error);
+    }
+    else
+    {
+        getLogger().log(
+            std::format("Creating event log for faulted fan {} sensor {}",
+                        fanPath, sensor.name()),
+            Logger::error);
+    }
 
     // In order to know if the event log should have a severity of error or
     // informational, count the number of existing nonfunctional sensors and
     // compare it to _numNonfuncSensorsBeforeError.
     size_t nonfuncSensors = 0;
-    for (const auto& fan : _fans)
+    for (const auto& f : _fans)
     {
-        for (const auto& s : fan->sensors())
+        for (const auto& s : f->sensors())
         {
             // Don't count nonfunctional sensors that still have their
             // error timer running as nonfunctional since they haven't
@@ -451,14 +482,25 @@ void System::sensorErrorTimerExpired(const Fan& fan, const TachSensor& sensor)
     }
 
     Severity severity = Severity::Error;
-    if (nonfuncSensors < _numNonfuncSensorsBeforeError)
-    {
-        severity = Severity::Informational;
-    }
+    std::unique_ptr<FanError> error;
 
-    auto error =
-        std::make_unique<FanError>("xyz.openbmc_project.Fan.Error.Fault",
-                                   fanPath, sensor.name(), severity);
+    if (!malfunctioning)
+    {
+        if (nonfuncSensors < _numNonfuncSensorsBeforeError)
+        {
+            severity = Severity::Informational;
+        }
+
+        error =
+            std::make_unique<FanError>("xyz.openbmc_project.Fan.Error.Fault",
+                                       fanPath, sensor.name(), severity);
+    }
+    else
+    {
+        error = std::make_unique<FanError>(
+            "xyz.openbmc_project.Fan.Error.Malfunction", fanPath, sensor.name(),
+            severity, FanError::FanCalloutPriority::low);
+    }
 
     auto sensorData = captureSensorData();
     error->commit(sensorData);
@@ -597,6 +639,23 @@ void System::dumpDebugData(sdeventplus::source::Signal&,
     {
         file << std::setw(4) << output;
     }
+}
+
+bool System::isPowerStateOn()
+{
+    try
+    {
+        auto state = util::SDBusPlus::getProperty<int32_t>(
+            "/org/openbmc/control/power0", "org.openbmc.control.Power",
+            "state");
+        return static_cast<bool>(state);
+    }
+    catch (const std::exception& e)
+    {
+        getLogger().log(std::format("Failed reading power state: {}", e.what()),
+                        Logger::Priority::error);
+    }
+    return true;
 }
 
 } // namespace phosphor::fan::monitor

--- a/monitor/system.hpp
+++ b/monitor/system.hpp
@@ -17,6 +17,7 @@
 
 #include "fan.hpp"
 #include "fan_error.hpp"
+#include "malfunction_monitor.hpp"
 #include "power_off_rule.hpp"
 #include "power_state.hpp"
 #include "tach_sensor.hpp"
@@ -131,6 +132,70 @@ class System
     void dumpDebugData(sdeventplus::source::Signal&,
                        const struct signalfd_siginfo*);
 
+    /**
+     * @brief Checks if the sensor shows evidence of a fan controller
+     *        malfunction, if malfunction checking is enabled.
+     *
+     * Recovery may be attempted if it's the first time hit.
+     *
+     * @param[in] sensor - The sensor to check
+     *
+     * @return bool - If a malfunction is detected
+     */
+    inline bool checkForMalfunction(const TachSensor& sensor)
+    {
+        if (malfunctionMonitor)
+        {
+            return malfunctionMonitor->checkAndAttemptRecovery(sensor);
+        }
+        return false;
+    }
+
+    /**
+     * @brief Prepares for the fan controller to be reset
+     */
+    inline void prepForCtlrReset()
+    {
+        std::ranges::for_each(_fans, [](auto& fan) {
+            fan->prepForCtlrReset();
+        });
+    }
+
+    /**
+     * @brief Says if the fan is showing evidence of a controller
+     *        malfunction, if checking is enabled.
+     *
+     * @param[in] fan - The fan to check
+     *
+     * @return bool - If the fan is showing a controller malfunction
+     */
+    inline bool isMalfunctioning(const Fan& fan) const
+    {
+        if (malfunctionMonitor)
+        {
+            return malfunctionMonitor->isFanAffected(fan.getName());
+        }
+        return false;
+    }
+
+    /**
+     * @brief Captures tach sensor data as JSON for use in
+     *        fan fault and fan missing event logs.
+     *
+     * @return json - The JSON data
+     */
+    json captureSensorData();
+
+    /**
+     * @brief Says if the 'state' property on the org.open_bmc.control.Power
+     *        interface is on.
+     *
+     * This property reflects the input state of the power control device.
+     *
+     * @return bool - If the state is on or not.
+     */
+    static bool isPowerStateOn();
+
   private:
     /**
      * @brief Callback from D-Bus when Inventory service comes online
@@ -212,12 +277,11 @@ class System
     static const std::string dumpFile;
 
     /**
-     * @brief Captures tach sensor data as JSON for use in
-     *        fan fault and fan missing event logs.
-     *
-     * @return json - The JSON data
+     * @brief Object that can monitor for and possibly recover
+     *        from fan controler malfunctions, if the fan
+     *        controller supports it.
      */
-    json captureSensorData();
+    std::unique_ptr<MalfunctionMonitor> malfunctionMonitor;
 
     /**
      * @brief creates a subscription (service->sensor) to take sensors
@@ -289,6 +353,8 @@ class System
      * @param[in] jsonObj - JSON object to parse from
      */
     void setFaultConfig(const json& jsonObj);
+
+    void setMalfunctionMonitor(const json& jsonObj);
 
     /**
      * @brief Log an error and shut down due to an offline fan controller

--- a/subprojects/libgpiod.wrap
+++ b/subprojects/libgpiod.wrap
@@ -1,0 +1,14 @@
+[wrap-file]
+directory = libgpiod-1.6.5
+source_url = https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/snapshot/libgpiod-1.6.5.tar.gz
+source_filename = libgpiod-1.6.5.tar.gz
+source_hash = 1473d3035b506065393a4569763cf6b5c98e59c8f865326374ebadffa2578f3a
+patch_filename = libgpiod_1.6.5-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/libgpiod_1.6.5-1/get_patch
+patch_hash = a8ee005ecaeaf9d4382d196a1b82e808e72b750f6b8cf61b84f7ccee134b8d4f
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/libgpiod_1.6.5-1/libgpiod-1.6.5.tar.gz
+wrapdb_version = 1.6.5-1
+
+[provide]
+libgpiod = gpiod_dep
+libgpiodcxx = gpiodcxx_dep


### PR DESCRIPTION
The MAX31785 fan controller has several times in the field shown RPM values of exactly 29104 RPM, leading to fan callouts for healthy fans and sometimes system shutdowns. This is considered a malfunction, since there is no known reason why this would happen.

It is suspected that resetting the chip will clear that error and allow the system to keep functioning without an immediate need for service. Resets can be using a GPIO wired from the BMC to the reset input on the MAX31785 for systems that have that wired.

This commit creates a new MalfunctionMonitor class to handle this workaround.  It does the following:

- Reads the reset GPIO name and tach trigger value out of an optional section in the JSON config file.  If it isn't present, then the functionality won't be enabled.
- Watches for tach sensor values over that limit.  On the first one that is it will:
  - Reset the fan controller using the GPIO.
  - Stop the fan monitor function for 15s to let the fan RPMs recover.
  - Create an informational event log saying the reset occurred.
  - Keep track of the fact that a reset was done and the sensor that hit it.
- It will only do one reset per power on, so if the same sensor or a new one is over the limit again, it will not reset again but will keep track of which fans have hit it.
- If a fan ends up getting called out, then the code will check if that fan has hit the malfunction as noted above.  If it has, then a unique event log will be created indicating that there was a malfunction. Otherwise, the typical fan fault event log will be created.
- On the power off, the state is cleared so the next power on can start fresh.

Tested: Injected various high tach readings at different times with special lab only code.

Examples of traces of a reset:
```
phosphor-fan-monitor[2449]: FanCtlr malfunction detected. Tach /xyz/openbmc_project/sensors/fan_tach/fan4_0 value 29104 is over limit.
phosphor-fan-monitor[2449]: Resetting fan controller to recover
```

And when the fan doesn't recover:
```
phosphor-fan-monitor[2449]: Creating event log for malfunctioning fan ctlr and sensor /xyz/openbmc_project/sensors/fan_tach/fan4_0
```


Change-Id: I493be2cfd2058f770299f6cfde8d782b530b7df9