### PR TITLE
monitor:configs: Add malfunction JSON

### DIFF
--- a/monitor/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.Bonnell/config.json
+++ b/monitor/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.Bonnell/config.json
@@ -72,5 +72,9 @@
                 "meltdown_delay": 60
             }
         ]
+    },
+    "runaway_tach_malfunction_handling": {
+        "gpio": "fan-ctlr-reset",
+        "tach_limit": 20000
     }
 }

--- a/monitor/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.Rainier1S4U/config.json
+++ b/monitor/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.Rainier1S4U/config.json
@@ -92,5 +92,9 @@
                 "meltdown_delay": 60
             }
         ]
+    },
+    "runaway_tach_malfunction_handling": {
+        "gpio": "fan-ctlr-reset",
+        "tach_limit": 20000
     }
 }

--- a/monitor/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.Rainier2U/config.json
+++ b/monitor/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.Rainier2U/config.json
@@ -172,5 +172,9 @@
                 "meltdown_delay": 60
             }
         ]
+    },
+    "runaway_tach_malfunction_handling": {
+        "gpio": "fan-ctlr-reset",
+        "tach_limit": 20000
     }
 }

--- a/monitor/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.Rainier4U/config.json
+++ b/monitor/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.Rainier4U/config.json
@@ -128,5 +128,9 @@
                 "meltdown_delay": 60
             }
         ]
+    },
+    "runaway_tach_malfunction_handling": {
+        "gpio": "fan-ctlr-reset",
+        "tach_limit": 20000
     }
 }


### PR DESCRIPTION
Rainier and Bonnell have the MAX31785 pin wired to a BMC GPIO so the fan malfunction workaround code can be enabled.  Set the reset GPIO name to 'fan-ctlr-reset' and the tach limit to 20000 RPM which is what the system team requested.


Change-Id: I477df9aee4fd5abf582bbd1c75dbf96b55e7bcf2