### PR TITLE
control:configs:Everest: Add a new floor index

### DIFF
--- a/control/config_files/p10bmc/ibm,everest/events.json
+++ b/control/config_files/p10bmc/ibm,everest/events.json
@@ -2373,7 +2373,8 @@
                                 "floors": [
                                     { "value": 1, "floor": 3800 },
                                     { "value": 2, "floor": 4200 },
-                                    { "value": 3, "floor": 4600 }
+                                    { "value": 3, "floor": 4600 },
+                                    { "value": 4, "floor": 6500 }
                                 ]
                             }
                         ]
@@ -2389,7 +2390,8 @@
                                 "floors": [
                                     { "value": 1, "floor": 4400 },
                                     { "value": 2, "floor": 4800 },
-                                    { "value": 3, "floor": 5400 }
+                                    { "value": 3, "floor": 5400 },
+                                    { "value": 4, "floor": 7500 }
                                 ]
                             }
                         ]
@@ -2405,7 +2407,8 @@
                                 "floors": [
                                     { "value": 1, "floor": 5000 },
                                     { "value": 2, "floor": 5600 },
-                                    { "value": 3, "floor": 6500 }
+                                    { "value": 3, "floor": 6500 },
+                                    { "value": 4, "floor": 9000 }
                                 ]
                             }
                         ]
@@ -2421,7 +2424,8 @@
                                 "floors": [
                                     { "value": 1, "floor": 5800 },
                                     { "value": 2, "floor": 6700 },
-                                    { "value": 3, "floor": 7700 }
+                                    { "value": 3, "floor": 7700 },
+                                    { "value": 4, "floor": 11300 }
                                 ]
                             }
                         ]
@@ -2437,7 +2441,8 @@
                                 "floors": [
                                     { "value": 1, "floor": 6900 },
                                     { "value": 2, "floor": 7900 },
-                                    { "value": 3, "floor": 9200 }
+                                    { "value": 3, "floor": 9200 },
+                                    { "value": 4, "floor": 11300 }
                                 ]
                             }
                         ]

--- a/control/config_files/p10bmc/ibm,everest/pcie_cards.json
+++ b/control/config_files/p10bmc/ibm,everest/pcie_cards.json
@@ -102,7 +102,7 @@
             "device_id": "0x1019",
             "subsystem_vendor_id": "0x1014",
             "subsystem_id": "0x0635",
-            "floor_index": 2
+            "floor_index": 4
         },
         {
             "name": "Bono HMS",
@@ -118,7 +118,7 @@
             "device_id": "0x101D",
             "subsystem_vendor_id": "0x1014",
             "subsystem_id": "0x06A6",
-            "floor_index": 3
+            "floor_index": 4
         },
         {
             "name": "Cedar Lake Crypto 100G 2port",
@@ -126,7 +126,7 @@
             "device_id": "0x101D",
             "subsystem_vendor_id": "0x1014",
             "subsystem_id": "0x06A5",
-            "floor_index": 3
+            "floor_index": 4
         },
         {
             "name": "Castello",

--- a/docs/control/events.md
+++ b/docs/control/events.md
@@ -645,10 +645,28 @@ from maximum group property value. The mapping is based on a provided table. If
 there are more than one event using this action, the maximum speed derived from
 the mapping of all groups will be set to the zone's target.
 
-... { "name": "target_from_group_max", "groups": [ { "name":
-"zone0_ambient", "interface": "xyz.openbmc_project.Sensor.Value", "property":
-{ "name": "Value" } } ], "neg_hysteresis": 1, "pos_hysteresis": 0, "map": [
-{ "value": 10.0, "target": 38.0 }, ... ] }
+```json
+{
+  "name": "target_from_group_max",
+  "groups": [
+    {
+      "name": "zone0_ambient",
+      "interface": "xyz.openbmc_project.Sensor.Value",
+      "property": {
+        "name": "Value"
+      }
+    }
+  ],
+  "neg_hysteresis": 1,
+  "pos_hysteresis": 0,
+  "map": [
+    {
+      "value": 10.0,
+      "target": 38.0
+    }
+  ]
+}
+```
 
 The above JSON will cause the action to read the property specified in the group
 "zone0_ambient" from all members of the group. The change in the group's members


### PR DESCRIPTION
Add a new floor index of 4, and change the Cedar Lake and Haleakala cards to use it.


Change-Id: Icd8fd365f756e3d36199237dec2d478aa8091f0e