### PR TITLE
control:configs:Everest: Add a new floor index

### DIFF
--- a/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.Everest/events.json
+++ b/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.Everest/events.json
@@ -2373,7 +2373,8 @@
                                 "floors": [
                                     { "value": 1, "floor": 3800 },
                                     { "value": 2, "floor": 4200 },
-                                    { "value": 3, "floor": 4600 }
+                                    { "value": 3, "floor": 4600 },
+                                    { "value": 4, "floor": 6500 }
                                 ]
                             }
                         ]
@@ -2389,7 +2390,8 @@
                                 "floors": [
                                     { "value": 1, "floor": 4400 },
                                     { "value": 2, "floor": 4800 },
-                                    { "value": 3, "floor": 5400 }
+                                    { "value": 3, "floor": 5400 },
+                                    { "value": 4, "floor": 7500 }
                                 ]
                             }
                         ]
@@ -2405,7 +2407,8 @@
                                 "floors": [
                                     { "value": 1, "floor": 5000 },
                                     { "value": 2, "floor": 5600 },
-                                    { "value": 3, "floor": 6500 }
+                                    { "value": 3, "floor": 6500 },
+                                    { "value": 4, "floor": 9000 }
                                 ]
                             }
                         ]
@@ -2421,7 +2424,8 @@
                                 "floors": [
                                     { "value": 1, "floor": 5800 },
                                     { "value": 2, "floor": 6700 },
-                                    { "value": 3, "floor": 7700 }
+                                    { "value": 3, "floor": 7700 },
+                                    { "value": 4, "floor": 11300 }
                                 ]
                             }
                         ]
@@ -2437,7 +2441,8 @@
                                 "floors": [
                                     { "value": 1, "floor": 6900 },
                                     { "value": 2, "floor": 7900 },
-                                    { "value": 3, "floor": 9200 }
+                                    { "value": 3, "floor": 9200 },
+                                    { "value": 4, "floor": 11300 }
                                 ]
                             }
                         ]

--- a/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.Everest/pcie_cards.json
+++ b/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.Everest/pcie_cards.json
@@ -102,7 +102,7 @@
             "device_id": "0x1019",
             "subsystem_vendor_id": "0x1014",
             "subsystem_id": "0x0635",
-            "floor_index": 2
+            "floor_index": 4
         },
         {
             "name": "Bono HMS",
@@ -118,7 +118,7 @@
             "device_id": "0x101D",
             "subsystem_vendor_id": "0x1014",
             "subsystem_id": "0x06A6",
-            "floor_index": 3
+            "floor_index": 4
         },
         {
             "name": "Cedar Lake Crypto 100G 2port",
@@ -126,7 +126,7 @@
             "device_id": "0x101D",
             "subsystem_vendor_id": "0x1014",
             "subsystem_id": "0x06A5",
-            "floor_index": 3
+            "floor_index": 4
         },
         {
             "name": "Castello",

--- a/control/json/utils/pcie_card_metadata.hpp
+++ b/control/json/utils/pcie_card_metadata.hpp
@@ -33,8 +33,7 @@ namespace phosphor::fan::control::json
  * fan floor index or temp sensor name based on its metadata, which
  * consists of 4 properties from the PCIeDevice D-Bus interface.
  *
- * The metadata is stored in one or more (see loadCards) JSON files, which
- * look like:
+ * The metadata is stored in a JSON file, which looks like:
  *  {
  *    "cards": [
  *      {
@@ -116,12 +115,8 @@ class PCIeCardMetadata
      * It will load a pcie_cards.json file in the default location if it
      * is present.
      *
-     * If systemNames isn't empty, it will load in any 'pcie_cards.json'
-     * files it finds in directories based on those names, overwriting any
-     * entries that were in any previous files.  This allows different
-     * floor indexes for some cards for the different systems in a flash
-     * image without needing to specify every possible card in every
-     * system specific JSON file.
+     * If systemNames isn't empty, it will load the first 'pcie_cards.json'
+     * files it finds in directories based on those names.
      *
      * If no valid config files are found it will throw an exception.
      *


### PR DESCRIPTION
Add a new floor index of 4, and change the Cedar Lake and Haleakala cards to use it.


Change-Id: Icd8fd365f756e3d36199237dec2d478aa8091f0e