### PR TITLE
control:ibm,Rainier: Add hot PCIe card

### DIFF
--- a/control/config_files/p10bmc/ibm,rainier-1s4u/pcie_cards.json
+++ b/control/config_files/p10bmc/ibm,rainier-1s4u/pcie_cards.json
@@ -199,6 +199,14 @@
             "subsystem_vendor_id": "0x1014",
             "subsystem_id": "0x06C6",
             "floor_index": 3
+        },
+        {
+            "name": "Moso PCIe4 64Gb 2-port Fibre Channel Adapter",
+            "vendor_id": "0x1077",
+            "device_id": "0x2289",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x06C5",
+            "floor_index": 2
         }
     ]
 }

--- a/control/config_files/p10bmc/ibm,rainier-2u/pcie_cards.json
+++ b/control/config_files/p10bmc/ibm,rainier-2u/pcie_cards.json
@@ -183,6 +183,14 @@
             "subsystem_vendor_id": "0x1014",
             "subsystem_id": "0x0617",
             "floor_index": 5
+        },
+        {
+            "name": "Moso PCIe4 64Gb 2-port Fibre Channel Adapter",
+            "vendor_id": "0x1077",
+            "device_id": "0x2289",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x06C5",
+            "floor_index": 3
         }
     ]
 }

--- a/control/config_files/p10bmc/ibm,rainier-4u/pcie_cards.json
+++ b/control/config_files/p10bmc/ibm,rainier-4u/pcie_cards.json
@@ -215,6 +215,14 @@
             "subsystem_vendor_id": "0x1014",
             "subsystem_id": "0x06C6",
             "floor_index": 3
+        },
+        {
+            "name": "Moso PCIe4 64Gb 2-port Fibre Channel Adapter",
+            "vendor_id": "0x1077",
+            "device_id": "0x2289",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x06C5",
+            "floor_index": 2
         }
     ]
 }

--- a/hwmon_ffdc.cpp
+++ b/hwmon_ffdc.cpp
@@ -23,8 +23,10 @@ inline std::vector<std::string> executeCommand(const std::string& command)
     std::vector<std::string> output;
     std::array<char, 128> buffer;
 
-    std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(command.c_str(), "r"),
-                                                  pclose);
+    auto pipe_close = [](auto fd) { (void)pclose(fd); };
+
+    std::unique_ptr<FILE, decltype(pipe_close)> pipe(
+        popen(command.c_str(), "r"), pipe_close);
     if (!pipe)
     {
         getLogger().log(


### PR DESCRIPTION
Add the 'Moso' card to all Rainier models.

Also cherry picked in a commit from master that went in a while ago to fix a fail due to an updated glibc, which CI must have now.

Change-Id: I2ad38ea9926f76fe9324052ef68045bd086dcb63