### PR TITLE
control:ibm,Rainier: Add hot PCIe card

### DIFF
--- a/control/config_files/p10bmc/ibm,rainier-1s4u/pcie_cards.json
+++ b/control/config_files/p10bmc/ibm,rainier-1s4u/pcie_cards.json
@@ -215,6 +215,14 @@
             "subsystem_vendor_id": "0x1014",
             "subsystem_id": "0x0714",
             "floor_index": 3
+        },
+        {
+            "name": "Moso PCIe4 64Gb 2-port Fibre Channel Adapter",
+            "vendor_id": "0x1077",
+            "device_id": "0x2289",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x06C5",
+            "floor_index": 2
         }
     ]
 }

--- a/control/config_files/p10bmc/ibm,rainier-2u/pcie_cards.json
+++ b/control/config_files/p10bmc/ibm,rainier-2u/pcie_cards.json
@@ -191,6 +191,14 @@
             "subsystem_vendor_id": "0x1014",
             "subsystem_id": "0x0714",
             "floor_index": 5
+        },
+        {
+            "name": "Moso PCIe4 64Gb 2-port Fibre Channel Adapter",
+            "vendor_id": "0x1077",
+            "device_id": "0x2289",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x06C5",
+            "floor_index": 3
         }
     ]
 }

--- a/control/config_files/p10bmc/ibm,rainier-4u/pcie_cards.json
+++ b/control/config_files/p10bmc/ibm,rainier-4u/pcie_cards.json
@@ -231,6 +231,14 @@
             "subsystem_vendor_id": "0x1014",
             "subsystem_id": "0x0714",
             "floor_index": 3
+        },
+        {
+            "name": "Moso PCIe4 64Gb 2-port Fibre Channel Adapter",
+            "vendor_id": "0x1077",
+            "device_id": "0x2289",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x06C5",
+            "floor_index": 2
         }
     ]
 }


### PR DESCRIPTION
Add the 'Moso' card to all Rainier models.


Change-Id: I2ad38ea9926f76fe9324052ef68045bd086dcb63