### PR TITLE
control:p10bmc: Force retry on OCC active group

### DIFF
--- a/control/config_files/p10bmc/ibm,bonnell/events.json
+++ b/control/config_files/p10bmc/ibm,bonnell/events.json
@@ -95,12 +95,12 @@
         ],
         "triggers": [
             {
-                "class": "init",
-                "method": "name_has_owner"
-            },
-            {
                 "class": "signal",
                 "signal": "name_owner_changed"
+            },
+            {
+                "class": "init",
+                "method": "name_has_owner"
             }
         ],
         "actions": [
@@ -143,6 +143,37 @@
                         "target": 17000
                     }
                 ]
+            }
+        ]
+    },
+    {
+        "name": "Force retry on the OCC status objects",
+        "groups": [
+            {
+                "name": "occ objects",
+                "interface": "org.open_power.OCC.Status",
+                "property": { "name": "OccActive" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "timer",
+                "type": "oneshot",
+                "interval": 30000000,
+                "preload_groups": true
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_target_on_missing_owner",
+                "groups": [
+                    {
+                        "name": "occ objects",
+                        "interface": "org.open_power.OCC.Status",
+                        "property": { "name": "OccActive" }
+                    }
+                ],
+                "target": 17000
             }
         ]
     },

--- a/control/config_files/p10bmc/ibm,everest/events.json
+++ b/control/config_files/p10bmc/ibm,everest/events.json
@@ -234,12 +234,12 @@
         ],
         "triggers": [
             {
-                "class": "init",
-                "method": "name_has_owner"
-            },
-            {
                 "class": "signal",
                 "signal": "name_owner_changed"
+            },
+            {
+                "class": "init",
+                "method": "name_has_owner"
             }
         ],
         "actions": [
@@ -287,6 +287,37 @@
                         "target": 9700
                     }
                 ]
+            }
+        ]
+    },
+    {
+        "name": "Force retry on the OCC status objects",
+        "groups": [
+            {
+                "name": "occ objects",
+                "interface": "org.open_power.OCC.Status",
+                "property": { "name": "OccActive" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "timer",
+                "type": "oneshot",
+                "interval": 30000000,
+                "preload_groups": true
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_target_on_missing_owner",
+                "groups": [
+                    {
+                        "name": "occ objects",
+                        "interface": "org.open_power.OCC.Status",
+                        "property": { "name": "OccActive" }
+                    }
+                ],
+                "target": 9700
             }
         ]
     },

--- a/control/config_files/p10bmc/ibm,rainier-1s4u/events.json
+++ b/control/config_files/p10bmc/ibm,rainier-1s4u/events.json
@@ -115,12 +115,12 @@
         ],
         "triggers": [
             {
-                "class": "init",
-                "method": "name_has_owner"
-            },
-            {
                 "class": "signal",
                 "signal": "name_owner_changed"
+            },
+            {
+                "class": "init",
+                "method": "name_has_owner"
             }
         ],
         "actions": [
@@ -173,6 +173,37 @@
                         "target": 10400
                     }
                 ]
+            }
+        ]
+    },
+    {
+        "name": "Force retry on the OCC status objects",
+        "groups": [
+            {
+                "name": "occ objects",
+                "interface": "org.open_power.OCC.Status",
+                "property": { "name": "OccActive" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "timer",
+                "type": "oneshot",
+                "interval": 30000000,
+                "preload_groups": true
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_target_on_missing_owner",
+                "groups": [
+                    {
+                        "name": "occ objects",
+                        "interface": "org.open_power.OCC.Status",
+                        "property": { "name": "OccActive" }
+                    }
+                ],
+                "target": 10400
             }
         ]
     },

--- a/control/config_files/p10bmc/ibm,rainier-2u/events.json
+++ b/control/config_files/p10bmc/ibm,rainier-2u/events.json
@@ -307,12 +307,12 @@
         ],
         "triggers": [
             {
-                "class": "init",
-                "method": "name_has_owner"
-            },
-            {
                 "class": "signal",
                 "signal": "name_owner_changed"
+            },
+            {
+                "class": "init",
+                "method": "name_has_owner"
             }
         ],
         "actions": [
@@ -365,6 +365,37 @@
                         "target": 18000
                     }
                 ]
+            }
+        ]
+    },
+    {
+        "name": "Force retry on the OCC status objects",
+        "groups": [
+            {
+                "name": "occ objects",
+                "interface": "org.open_power.OCC.Status",
+                "property": { "name": "OccActive" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "timer",
+                "type": "oneshot",
+                "interval": 30000000,
+                "preload_groups": true
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_target_on_missing_owner",
+                "groups": [
+                    {
+                        "name": "occ objects",
+                        "interface": "org.open_power.OCC.Status",
+                        "property": { "name": "OccActive" }
+                    }
+                ],
+                "target": 18000
             }
         ]
     },

--- a/control/config_files/p10bmc/ibm,rainier-4u/events.json
+++ b/control/config_files/p10bmc/ibm,rainier-4u/events.json
@@ -125,12 +125,12 @@
         ],
         "triggers": [
             {
-                "class": "init",
-                "method": "name_has_owner"
-            },
-            {
                 "class": "signal",
                 "signal": "name_owner_changed"
+            },
+            {
+                "class": "init",
+                "method": "name_has_owner"
             }
         ],
         "actions": [
@@ -183,6 +183,37 @@
                         "target": 10400
                     }
                 ]
+            }
+        ]
+    },
+    {
+        "name": "Force retry on the OCC status objects",
+        "groups": [
+            {
+                "name": "occ objects",
+                "interface": "org.open_power.OCC.Status",
+                "property": { "name": "OccActive" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "timer",
+                "type": "oneshot",
+                "interval": 30000000,
+                "preload_groups": true
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_target_on_missing_owner",
+                "groups": [
+                    {
+                        "name": "occ objects",
+                        "interface": "org.open_power.OCC.Status",
+                        "property": { "name": "OccActive" }
+                    }
+                ],
+                "target": 10400
             }
         ]
     },


### PR DESCRIPTION
Thirty seconds after fan control has started, check again if the service hosting the OccActive property can be found, and release the existing target hold if there was one from when the set_target_on_missing_owner action originally ran.

Thirty seconds was chosen to be far out enough to let thing settle down a bit.

This is to work around a problem where the OCC service wasn't running the first time fan control checked, and then it somehow missed the NameOwnerChanged signal so the target hold from the set_target_on_missing_owner action was permanently set.

There is also a change to switch the order of the triggers in the 'service(s) missing' action to add the NameOwnerChanged match before checking if the name has an owner, closing a very small window where it was possible the signal came in after the check but before the match was added.

Tested:
By adding traces, viewed that the new action ran 30 seconds after startup, and that the order of the triggers was changed.


Change-Id: I5a74a09a066757207fbf9a598aa7282aae2b58ce