### PR TITLE
control: In Fan::setTarget, allow same fan target

### DIFF
--- a/control/json/fan.cpp
+++ b/control/json/fan.cpp
@@ -100,9 +100,12 @@ void Fan::setZone(const json& jsonObj)
 
 void Fan::setTarget(uint64_t target)
 {
-    if ((_target == target) || !_lockedTargets.empty())
+    // If there is a target lock, continue but use
+    // the highest locked value.
+    auto maxLock = std::ranges::max_element(_lockedTargets);
+    if (maxLock != _lockedTargets.end())
     {
-        return;
+        target = *maxLock;
     }
 
     for (const auto& sensor : _sensors)


### PR DESCRIPTION
In "b43a007 control: Periodically write out target values", fan control started writing out the current fan targets every five seconds, even if they didn't change. This was to handle the case where the fan controller would reset itself and the device would revert to some previous target values without it being reflected on D-Bus, which would be seen as fan faults.

However, that fix was incomplete, as Fan::setTarget would just return immediately if the target to set already matched the target value stored in the class.

Remove that check so that it now keeps going to write the value to D-Bus.

Also, there is a concept of a locked target which is where a specific fan has a different target than the rest of the fans in the zone due to a configured fan action.  In the case that there is a locked target on a fan, set that locked target value instead of the passed in value, which comes from the zone.

Tested:
Change the target in sysfs, and then watch it get written back to what it was before:

```
$ grep . fan*_target
fan1_target:5000
fan2_target:5000
fan3_target:5000
fan4_target:5000

$ for f in {1..4}; do echo 4000 > fan$f"_target"; done

$ grep . fan*_target
fan1_target:4000
fan2_target:4000
fan3_target:4000
fan4_target:4000

$ sleep 5

$ grep . fan*_target
fan1_target:5000
fan2_target:5000
fan3_target:5000
fan4_target:5000
```

Do the same with a locked fan target:
```
$ grep . fan*_target
fan1_target:11300  <-- locked to 11300
fan2_target:5000
fan3_target:5000
fan4_target:5000

$ for f in {1..4}; do echo 4000 > fan$f"_target"; done

$ grep . fan*_target
fan1_target:4000
fan2_target:4000
fan3_target:4000
fan4_target:4000

$ sleep 5

$ grep . fan*_target
fan1_target:11300
fan2_target:5000
fan3_target:5000
fan4_target:5000
```


Change-Id: I04b28e32603e8a670fc3d04cf460edfaa1a313b5