### PR TITLE
configs:ibm: Add Balcones Support

### DIFF
--- a/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.Balcones/events.json
+++ b/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.Balcones/events.json
@@ -1,0 +1,1228 @@
+[
+    {
+        // Hold fans at the given target when a number of fans are missing.
+        "name": "fan(s) missing",
+        "groups": [
+            {
+                "name": "fan inventory",
+                "interface": "xyz.openbmc_project.Inventory.Item",
+                "property": { "name": "Present" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            }
+        ],
+        "actions": [
+            {
+                "name": "count_state_before_target",
+                "count": 1,
+                "state": false,
+                "target": 17000
+            }
+        ]
+    },
+    {
+        // Hold fans at the given target when a number of rotors are nonfunctional.
+        "name": "fan rotor(s) faulted",
+        "groups": [
+            {
+                "name": "fan0 rotor inventory",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "fan1 rotor inventory",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            }
+        ],
+        "actions": [
+            {
+                "name": "count_state_before_target",
+                "count": 1,
+                "state": false,
+                "target": 17000
+            }
+        ]
+    },
+    {
+        // Hold fans at the given target when any critical service
+        // is not running for 5 seconds.
+        "name": "service(s) missing",
+        "groups": [
+            {
+                "name": "fan inventory",
+                "interface": "xyz.openbmc_project.Inventory.Item",
+                "property": { "name": "Present" }
+            },
+            {
+                "name": "occ objects",
+                "interface": "org.open_power.OCC.Status",
+                "property": { "name": "OccActive" }
+            },
+            {
+                "name": "nvme temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "pcie cable card temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "ambient temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "altitude",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "signal",
+                "signal": "name_owner_changed"
+            },
+            {
+                "class": "init",
+                "method": "name_has_owner"
+            }
+        ],
+        "actions": [
+            {
+                "name": "call_actions_based_on_timer",
+                "timer": {
+                    "interval": 5000000,
+                    "type": "oneshot"
+                },
+                "actions": [
+                    {
+                        "name": "set_target_on_missing_owner",
+                        "groups": [
+                            {
+                                "name": "fan inventory",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property": { "name": "Present" }
+                            },
+                            {
+                                "name": "occ objects",
+                                "interface": "org.open_power.OCC.Status",
+                                "property": { "name": "OccActive" }
+                            },
+                            {
+                                "name": "nvme temps",
+                                "interface": "xyz.openbmc_project.Sensor.Value",
+                                "property": { "name": "Value" }
+                            },
+                            {
+                                "name": "pcie cable card temps",
+                                "interface": "xyz.openbmc_project.Sensor.Value",
+                                "property": { "name": "Value" }
+                            },
+                            {
+                                "name": "ambient temp",
+                                "interface": "xyz.openbmc_project.Sensor.Value",
+                                "property": { "name": "Value" }
+                            },
+                            {
+                                "name": "altitude",
+                                "interface": "xyz.openbmc_project.Sensor.Value",
+                                "property": { "name": "Value" }
+                            }
+                        ],
+                        "target": 17000
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Force retry on the OCC status objects",
+        "groups": [
+            {
+                "name": "occ objects",
+                "interface": "org.open_power.OCC.Status",
+                "property": { "name": "OccActive" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "timer",
+                "type": "oneshot",
+                "interval": 30000000,
+                "preload_groups": true
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_target_on_missing_owner",
+                "groups": [
+                    {
+                        "name": "occ objects",
+                        "interface": "org.open_power.OCC.Status",
+                        "property": { "name": "OccActive" }
+                    }
+                ],
+                "target": 17000
+            }
+        ]
+    },
+    {
+        // Set a fan floor if an OCC isn't active
+        "name": "Non-active OCCs",
+        "groups": [
+            {
+                "name": "occ objects",
+                "interface": "org.open_power.OCC.Status",
+                "property": {
+                    "name": "OccActive"
+                }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            },
+            {
+                "class": "init",
+                "method": "get_properties"
+            }
+        ],
+        "actions": [
+            {
+                "name": "count_state_floor",
+                "count": 1,
+                "state": false,
+                "floor": 17000
+            }
+        ]
+    },
+    {
+        // Set a raised fan floor when any temperature or altitude sensor is
+        // nonfunctional
+        "name": "Nonfunctional temperature sensors",
+        "groups": [
+            {
+                "name": "proc0 core temps",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "proc0 ioring temp",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "dram temps",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "pmic temps",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "internal memory buffer temps",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "dram and external memory buffer temps",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "external memory buffer temps",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "vdd vrm temps",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "nvme temps",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "pcie cable card temps",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "ambient temp",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "altitude",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_removed"
+            },
+            {
+                "class": "init",
+                "method": "get_properties"
+            }
+        ],
+        "actions": [
+            {
+                "name": "count_state_floor",
+                "count": 1,
+                "state": false,
+                "delay": 5,
+                "floor": 17000
+            }
+        ]
+    },
+    {
+        "name": "Set Proc 0 Core DVFS parameter",
+        "groups": [
+            {
+                "name": "proc 0 core dvfs temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_0_core_dvfs_increase_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 10
+                }
+            },
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_0_core_dvfs_decrease_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 13
+                }
+            }
+        ]
+    },
+    {
+        "name": "Set Proc 0 IO Ring DVFS parameter",
+        "groups": [
+            {
+                "name": "proc 0 ioring dvfs temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_0_ioring_dvfs_increase_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 10
+                }
+            },
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_0_ioring_dvfs_decrease_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 13
+                }
+            }
+        ]
+    },
+    {
+        "name": "Set DRAM DVFS parameter",
+        "groups": [
+            {
+                "name": "dram dvfs temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "dram_dvfs_increase_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 9
+                }
+            },
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "dram_dvfs_decrease_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 12
+                }
+            }
+        ]
+    },
+    {
+        "name": "Set PMIC DVFS parameter",
+        "groups": [
+            {
+                "name": "pmic dvfs temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "pmic_dvfs_increase_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 9
+                }
+            },
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "pmic_dvfs_decrease_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 12
+                }
+            }
+        ]
+    },
+    {
+        "name": "Set internal memory buffer DVFS parameter",
+        "groups": [
+            {
+                "name": "internal memory buffer dvfs temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "intmb_dvfs_increase_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 10
+                }
+            },
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "intmb_dvfs_decrease_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 13
+                }
+            }
+        ]
+    },
+    {
+        "name": "Set DRAM and external memory buffer DVFS parameter",
+        "groups": [
+            {
+                "name": "dram and external memory buffer dvfs temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "dram_extmb_dvfs_increase_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 10
+                }
+            },
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "dram_extmb_dvfs_decrease_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 13
+                }
+            }
+        ]
+    },
+    {
+        "name": "Set external memory buffer DVFS parameter",
+        "groups": [
+            {
+                "name": "external memory buffer dvfs temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "extmb_dvfs_increase_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 10
+                }
+            },
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "extmb_dvfs_decrease_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 13
+                }
+            }
+        ]
+    },
+    {
+        // Collect group temperatures each iteration the repeating timer expires
+        "name": "Fan control timer loop",
+        "groups": [
+            {
+                "name": "proc0 core temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "proc0 ioring temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "dram temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "pmic temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "internal memory buffer temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "dram and external memory buffer temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "external memory buffer temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "vdd vrm temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "nvme temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "pcie cable card temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "timer",
+                "type": "repeating",
+                "interval": 2000000,
+                "preload_groups": true
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "proc0 core temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_0_core_dvfs_increase_temp",
+                "delta": 300
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "proc0 ioring temp",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_0_ioring_dvfs_increase_temp",
+                "delta": 300
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "dram temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "dram_dvfs_increase_temp",
+                "delta": 100
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "pmic temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "pmic_dvfs_increase_temp",
+                "delta": 100
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "internal memory buffer temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "intmb_dvfs_increase_temp",
+                "delta": 100
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "dram and external memory buffer temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "dram_extmb_dvfs_increase_temp",
+                "delta": 200
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "external memory buffer temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "extmb_dvfs_increase_temp",
+                "delta": 200
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "vdd vrm temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state": 82.0,
+                "delta": 300
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "nvme temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state": 58.0,
+                "delta": 200
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "pcie cable card temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state": 70.0,
+                "delta": 255
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "proc0 core temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_0_core_dvfs_decrease_temp",
+                "delta": 50
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "proc0 ioring temp",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_0_ioring_dvfs_decrease_temp",
+                "delta": 50
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "dram temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "dram_dvfs_decrease_temp",
+                "delta": 40
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "pmic temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "pmic_dvfs_decrease_temp",
+                "delta": 40
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "internal memory buffer temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "intmb_dvfs_decrease_temp",
+                "delta": 40
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "dram and external memory buffer temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "dram_extmb_dvfs_decrease_temp",
+                "delta": 40
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "external memory buffer temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "extmb_dvfs_decrease_temp",
+                "delta": 40
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "vdd vrm temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state": 79.0,
+                "delta": 30
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "nvme temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state": 55.0,
+                "delta": 40
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "pcie cable card temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state": 65.0,
+                "delta": 80
+            }
+        ]
+    },
+    {
+        // Remove NVMe temperature objects from cache when they are removed from
+        // dbus. There's no need to react to their removal.
+        "name": "remove nvme objects",
+        "groups": [
+            {
+                "name": "nvme temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "nvme temps",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "signal",
+                "signal": "interfaces_removed"
+            }
+        ]
+    },
+    {
+        "name": "set pcie floor index",
+        "groups": [
+            {
+                "name": "pcie slots",
+                "interface": "xyz.openbmc_project.State.Decorator.PowerState",
+                "property": {
+                    "name": "PowerState"
+                }
+            },
+            {
+                "name": "pcie cards",
+                "interface": "xyz.openbmc_project.Inventory.Item.PCIeDevice",
+                "property": {
+                    "name": "Function0DeviceId"
+                }
+            },
+            {
+                "name": "pcie cards",
+                "interface": "xyz.openbmc_project.Inventory.Item.PCIeDevice",
+                "property": {
+                    "name": "Function0VendorId"
+                }
+            },
+            {
+                "name": "pcie cards",
+                "interface": "xyz.openbmc_project.Inventory.Item.PCIeDevice",
+                "property": {
+                    "name": "Function0SubsystemId"
+                }
+            },
+            {
+                "name": "pcie cards",
+                "interface": "xyz.openbmc_project.Inventory.Item.PCIeDevice",
+                "property": {
+                    "name": "Function0SubsystemVendorId"
+                }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            }
+        ],
+        "actions": [
+            {
+                "name": "pcie_card_floors",
+                "use_config_specific_files": true,
+                "settle_time": 2
+            }
+        ]
+    },
+    {
+        "name": "Set altitude offset parameter",
+        "groups": [
+            {
+                "name": "altitude",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            },
+            {
+                // Refresh altitude every 24hrs
+                "class": "timer",
+                "type": "repeating",
+                "interval": 86400000000,
+                "preload_groups": true
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "ambient_24_5_altitude_offset",
+                "modifier": {
+                    "operator": "less_than",
+                    "default_value": 10000,
+                    "value": [
+                        { "arg_value": 500, "parameter_value": 0 },
+                        { "arg_value": 1000, "parameter_value": 180 },
+                        { "arg_value": 1500, "parameter_value": 320 },
+                        { "arg_value": 2000, "parameter_value": 650 },
+                        { "arg_value": 2500, "parameter_value": 1010 },
+                        { "arg_value": 3050, "parameter_value": 1370 }
+                    ]
+                }
+            },
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "ambient_29_5_altitude_offset",
+                "modifier": {
+                    "operator": "less_than",
+                    "default_value": 10000,
+                    "value": [
+                        { "arg_value": 500, "parameter_value": 0 },
+                        { "arg_value": 1000, "parameter_value": 200 },
+                        { "arg_value": 1500, "parameter_value": 340 },
+                        { "arg_value": 2000, "parameter_value": 580 },
+                        { "arg_value": 2500, "parameter_value": 950 },
+                        { "arg_value": 3050, "parameter_value": 1500 }
+                    ]
+                }
+            },
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "ambient_34_5_altitude_offset",
+                "modifier": {
+                    "operator": "less_than",
+                    "default_value": 10000,
+                    "value": [
+                        { "arg_value": 500, "parameter_value": 0 },
+                        { "arg_value": 1000, "parameter_value": 250 },
+                        { "arg_value": 1500, "parameter_value": 580 },
+                        { "arg_value": 2000, "parameter_value": 980 },
+                        { "arg_value": 2500, "parameter_value": 1430 },
+                        { "arg_value": 3050, "parameter_value": 1930 }
+                    ]
+                }
+            },
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "ambient_39_5_altitude_offset",
+                "modifier": {
+                    "operator": "less_than",
+                    "default_value": 10000,
+                    "value": [
+                        { "arg_value": 500, "parameter_value": 0 },
+                        { "arg_value": 1000, "parameter_value": 340 },
+                        { "arg_value": 1500, "parameter_value": 720 },
+                        { "arg_value": 2000, "parameter_value": 1180 },
+                        { "arg_value": 2500, "parameter_value": 1800 },
+                        { "arg_value": 3050, "parameter_value": 2550 }
+                    ]
+                }
+            },
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "ambient_44_5_altitude_offset",
+                "modifier": {
+                    "operator": "less_than",
+                    "default_value": 10000,
+                    "value": [
+                        { "arg_value": 500, "parameter_value": 0 },
+                        { "arg_value": 1000, "parameter_value": 450 },
+                        { "arg_value": 1500, "parameter_value": 1050 },
+                        { "arg_value": 2000, "parameter_value": 1820 },
+                        { "arg_value": 2500, "parameter_value": 2590 },
+                        { "arg_value": 3050, "parameter_value": 3360 }
+                    ]
+                }
+            }
+        ]
+    },
+    {
+        "name": "Fan floors",
+        "groups": [
+            {
+                "name": "ambient temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            },
+            {
+                "class": "parameter",
+                "parameter": "pcie_floor_index"
+            },
+            {
+                "class": "parameter",
+                "parameter": "ambient_24_5_altitude_offset"
+            },
+            {
+                "class": "parameter",
+                "parameter": "ambient_29_5_altitude_offset"
+            },
+            {
+                "class": "parameter",
+                "parameter": "ambient_34_5_altitude_offset"
+            },
+            {
+                "class": "parameter",
+                "parameter": "ambient_39_5_altitude_offset"
+            },
+            {
+                "class": "parameter",
+                "parameter": "ambient_44_5_altitude_offset"
+            }
+        ],
+        "actions": [
+            {
+                "name": "mapped_floor",
+                "key_group": "ambient temp",
+                "fan_floors": [
+                    {
+                        // Entry valid for temps < 24.5
+                        "key": 24.5,
+                        "default_floor": 4130,
+                        "floor_offset_parameter": "ambient_24_5_altitude_offset",
+                        "floors": [
+                            {
+                                "parameter": "pcie_floor_index",
+                                "floors": [{ "value": 1, "floor": 6200 }]
+                            }
+                        ]
+                    },
+                    {
+                        // Entry valid for temps < 29.5
+                        "key": 29.5,
+                        "default_floor": 4810,
+                        "floor_offset_parameter": "ambient_29_5_altitude_offset",
+                        "floors": [
+                            {
+                                "parameter": "pcie_floor_index",
+                                "floors": [{ "value": 1, "floor": 6800 }]
+                            }
+                        ]
+                    },
+                    {
+                        // Entry valid for temps < 34.5
+                        "key": 34.5,
+                        "default_floor": 5930,
+                        "floor_offset_parameter": "ambient_34_5_altitude_offset",
+                        "floors": [
+                            {
+                                "parameter": "pcie_floor_index",
+                                "floors": [{ "value": 1, "floor": 7400 }]
+                            }
+                        ]
+                    },
+                    {
+                        // Entry valid for temps < 39.5
+                        "key": 39.5,
+                        "default_floor": 7940,
+                        "floor_offset_parameter": "ambient_39_5_altitude_offset",
+                        "floors": [
+                            {
+                                "parameter": "pcie_floor_index",
+                                "floors": [{ "value": 1, "floor": 8500 }]
+                            }
+                        ]
+                    },
+                    {
+                        // Entry valid for temps < 44.5
+                        "key": 44.5,
+                        "default_floor": 10670,
+                        "floor_offset_parameter": "ambient_44_5_altitude_offset",
+                        "floors": [
+                            {
+                                "parameter": "pcie_floor_index",
+                                "floors": [{ "value": 1, "floor": 9800 }]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+]

--- a/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.Balcones/fans.json
+++ b/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.Balcones/fans.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "fan0",
+        "zone": "0",
+        "sensors": ["fan0_0"],
+        "target_interface": "xyz.openbmc_project.Control.FanSpeed"
+    },
+    {
+        "name": "fan1",
+        "zone": "0",
+        "sensors": ["fan1_0"],
+        "target_interface": "xyz.openbmc_project.Control.FanSpeed"
+    }
+]

--- a/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.Balcones/groups.json
+++ b/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.Balcones/groups.json
@@ -1,0 +1,228 @@
+[
+    {
+        "name": "fan inventory",
+        "members": [
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan0",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan1"
+        ]
+    },
+    {
+        "name": "fan0 rotor inventory",
+        "members": [
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan0/fan0_0",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan0/fan0_1"
+        ]
+    },
+    {
+        "name": "fan1 rotor inventory",
+        "members": [
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan1/fan1_0",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan1/fan1_1"
+        ]
+    },
+    {
+        "name": "occ objects",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/org/open_power/control/occ0",
+            "/org/open_power/control/occ1"
+        ]
+    },
+    {
+        "name": "proc0 core temps",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc0_core0_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core0_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core1_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core1_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core2_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core2_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core3_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core3_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core4_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core4_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core5_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core5_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core6_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core6_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core7_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core7_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core8_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core8_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core9_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core9_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core10_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core10_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core11_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core11_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core12_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core12_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core13_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core13_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core14_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core14_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core15_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core15_1_temp"
+        ]
+    },
+    {
+        "name": "proc0 ioring temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc0_ioring_temp"
+        ]
+    },
+    {
+        "name": "dram temps",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/dimm0_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm1_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm2_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm3_dram_temp"
+        ]
+    },
+    {
+        "name": "dram dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/dimm_dram_dvfs_temp"
+        ]
+    },
+    {
+        "name": "pmic temps",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/dimm0_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm1_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm2_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm3_pmic_temp"
+        ]
+    },
+    {
+        "name": "pmic dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/dimm_pmic_dvfs_temp"
+        ]
+    },
+    {
+        "name": "internal memory buffer temps",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/dimm0_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm1_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm2_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm3_intmb_temp"
+        ]
+    },
+    {
+        "name": "internal memory buffer dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/dimm_intmb_dvfs_temp"
+        ]
+    },
+    {
+        "name": "dram and external memory buffer temps",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/dimm0_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm1_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm2_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm3_dram_extmb_temp"
+        ]
+    },
+    {
+        "name": "dram and external memory buffer dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/dimm_dram_extmb_dvfs_temp"
+        ]
+    },
+    {
+        "name": "external memory buffer temps",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/dimm0_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm1_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm2_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm3_extmb_temp"
+        ]
+    },
+    {
+        "name": "external memory buffer dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/dimm_extmb_dvfs_temp"
+        ]
+    },
+    {
+        "name": "vdd vrm temps",
+        "service": "org.open_power.OCC.Control",
+        "members": ["/xyz/openbmc_project/sensors/temperature/vrm_vdd0_temp"]
+    },
+    {
+        "name": "proc 0 core dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc0_core_dvfs_temp"
+        ]
+    },
+    {
+        "name": "proc 0 ioring dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc0_ioring_dvfs_temp"
+        ]
+    },
+    {
+        "name": "nvme temps",
+        "service": "xyz.openbmc_project.NVMeSensor",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/NVMe_1_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_2_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_3_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_4_Temp"
+        ]
+    },
+    {
+        // Bear River card
+        "name": "pcie cable card temps",
+        "service": "xyz.openbmc_project.HwmonTempSensor",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/PCIe_Cable_Card_C2_Temp"
+        ]
+    },
+    {
+        "name": "ambient temp",
+        "service": "xyz.openbmc_project.VirtualSensor",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/Ambient_Virtual_Temp"
+        ]
+    },
+    {
+        "name": "altitude",
+        "service": "xyz.openbmc_project.VirtualSensor",
+        "members": ["/xyz/openbmc_project/sensors/altitude/Altitude"]
+    },
+    {
+        "name": "pcie slots",
+        "members": [
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot0",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot1",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot2",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot3"
+        ]
+    },
+    {
+        "name": "pcie cards",
+        "members": [
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot0/pcie_card0",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot1/pcie_card1",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot2/pcie_card2",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot3/pcie_card3"
+        ]
+    }
+]

--- a/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.Balcones/pcie_cards.json
+++ b/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.Balcones/pcie_cards.json
@@ -1,0 +1,28 @@
+{
+    "cards": [
+        {
+            "name": "Bear Lake and Bear River",
+            "vendor_id": "0x1014",
+            "device_id": "0x04F2",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x0004",
+            "has_temp_sensor": true
+        },
+        {
+            "name": "PHYP had errors getting IDs",
+            "vendor_id": "0xFFFF",
+            "device_id": "0xFFFF",
+            "subsystem_vendor_id": "0xFFFF",
+            "subsystem_id": "0xFFFF",
+            "floor_index": 1
+        },
+        {
+            "name": "GTO",
+            "vendor_id": "0x1014",
+            "device_id": "0x034A",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x033B",
+            "floor_index": 1
+        }
+    ]
+}

--- a/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.Balcones/zones.json
+++ b/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.Balcones/zones.json
@@ -1,0 +1,9 @@
+[
+    {
+        "name": "0",
+        "poweron_target": 17000,
+        "default_floor": 17000,
+        "increase_delay": 5,
+        "decrease_interval": 30
+    }
+]

--- a/monitor/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.Balcones/config.json
+++ b/monitor/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.Balcones/config.json
@@ -1,0 +1,80 @@
+{
+    "fans": [
+        {
+            "inventory": "/system/chassis/motherboard/fan0",
+            "method": "count",
+            "count_interval": 1,
+            "deviation": 22,
+            "upper_deviation": 40,
+            "num_sensors_nonfunc_for_fan_nonfunc": 0,
+            "monitor_start_delay": 30,
+            "fan_missing_error_delay": 20,
+            "nonfunc_rotor_error_delay": 0,
+            "set_func_on_present": true,
+            "sensors": [
+                {
+                    "name": "fan0_0",
+                    "threshold": 30,
+                    "has_target": true
+                },
+                {
+                    "name": "fan0_1",
+                    "threshold": 30,
+                    "has_target": false,
+                    "factor": 0.685,
+                    "offset": 700
+                }
+            ]
+        },
+        {
+            "inventory": "/system/chassis/motherboard/fan1",
+            "method": "count",
+            "count_interval": 1,
+            "deviation": 22,
+            "upper_deviation": 40,
+            "num_sensors_nonfunc_for_fan_nonfunc": 0,
+            "monitor_start_delay": 30,
+            "fan_missing_error_delay": 20,
+            "nonfunc_rotor_error_delay": 0,
+            "set_func_on_present": true,
+            "sensors": [
+                {
+                    "name": "fan1_0",
+                    "threshold": 30,
+                    "has_target": true
+                },
+                {
+                    "name": "fan1_1",
+                    "threshold": 30,
+                    "has_target": false,
+                    "factor": 0.685,
+                    "offset": 700
+                }
+            ]
+        }
+    ],
+    "fault_handling": {
+        "num_nonfunc_rotors_before_error": 1,
+
+        "power_off_config": [
+            {
+                "type": "hard",
+                "cause": "missing_fan_frus",
+                "count": 1,
+                "delay": 25,
+                "state": "at_pgood"
+            },
+            {
+                "type": "epow",
+                "cause": "nonfunc_fan_rotors",
+                "count": 2,
+                "service_mode_delay": 300,
+                "meltdown_delay": 60
+            }
+        ]
+    },
+    "runaway_tach_malfunction_handling": {
+        "gpio": "fan-ctlr-reset",
+        "tach_limit": 20000
+    }
+}

--- a/presence/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.Balcones/config.json
+++ b/presence/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.Balcones/config.json
@@ -1,0 +1,40 @@
+[
+    {
+        "name": "fan0",
+        "path": "/system/chassis/motherboard/fan0",
+        "methods": [
+            {
+                "type": "gpio",
+                "key": 6,
+                "physpath": "BMC",
+                "devpath": "/dev/input/by-path/platform-gpio-keys-polled-event"
+            },
+            {
+                "type": "tach",
+                "sensors": ["fan0_0", "fan0_1"]
+            }
+        ],
+        "rpolicy": {
+            "type": "anyof"
+        }
+    },
+    {
+        "name": "fan1",
+        "path": "/system/chassis/motherboard/fan1",
+        "methods": [
+            {
+                "type": "gpio",
+                "key": 7,
+                "physpath": "BMC",
+                "devpath": "/dev/input/by-path/platform-gpio-keys-polled-event"
+            },
+            {
+                "type": "tach",
+                "sensors": ["fan1_0", "fan1_1"]
+            }
+        ],
+        "rpolicy": {
+            "type": "anyof"
+        }
+    }
+]


### PR DESCRIPTION
Create JSON config files in presence, monitor, and control applications to support power on for Balcones hardware.

Tested:
* Built firmware image and installed in simulation. Verified presence of Balcones JSON files on the simulated system.
* Modified simulated Rainier system JSON configuration to include Balcones system information. Verified that entity manager correctly identified Balcones information via the busctl command.
* Verified that control, monitor, and presence applications loaded JSON configurations from Balcones subdirectories via the journalctl command.

Change-Id: If2a3dc403b689e85b9afac2d2b6cb91a4e723c23