### PR TITLE
1120: configs:ibm: Fix DVFS Memory Throttling for Fuji

### DIFF
--- a/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.Fuji/events.json
+++ b/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.Fuji/events.json
@@ -1,0 +1,2485 @@
+[
+    {
+        // Hold fans at the given target when a number of fans are missing.
+        "name": "fan(s) missing",
+        "groups": [
+            {
+                "name": "fan inventory",
+                "interface": "xyz.openbmc_project.Inventory.Item",
+                "property": { "name": "Present" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            }
+        ],
+        "actions": [
+            {
+                "name": "count_state_before_target",
+                "count": 1,
+                "state": false,
+                "target": 11300
+            }
+        ]
+    },
+    {
+        // Hold fans at the given target when a number of rotors are nonfunctional.
+        "name": "fan rotor(s) faulted",
+        "groups": [
+            {
+                "name": "fan0 rotor inventory",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "fan1 rotor inventory",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "fan2 rotor inventory",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "fan3 rotor inventory",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            }
+        ],
+        "actions": [
+            {
+                "name": "count_state_before_target",
+                "count": 2,
+                "state": false,
+                "target": 11300
+            }
+        ]
+    },
+    {
+        // (for the following 4 rules)
+        // if a dual-rotor fan becomes non-functional, lock its speed to
+        // poweron_target to lock the other rotor to full_speed
+        "name": "nonfunc rotor override-0",
+        "groups": [
+            {
+                "name": "fan0 rotor inventory",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            }
+        ],
+        "actions": [
+            {
+                "name": "override_fan_target",
+                "count": 1,
+                "state": false,
+                "fans": ["fan0"],
+                "target": 11300
+            }
+        ]
+    },
+    {
+        "name": "nonfunc rotor override-1",
+        "groups": [
+            {
+                "name": "fan1 rotor inventory",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            }
+        ],
+        "actions": [
+            {
+                "name": "override_fan_target",
+                "count": 1,
+                "state": false,
+                "fans": ["fan1"],
+                "target": 11300
+            }
+        ]
+    },
+    {
+        "name": "nonfunc rotor override-2",
+        "groups": [
+            {
+                "name": "fan2 rotor inventory",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            }
+        ],
+        "actions": [
+            {
+                "name": "override_fan_target",
+                "count": 1,
+                "state": false,
+                "fans": ["fan2"],
+                "target": 11300
+            }
+        ]
+    },
+    {
+        "name": "nonfunc rotor override-3",
+        "groups": [
+            {
+                "name": "fan3 rotor inventory",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            }
+        ],
+        "actions": [
+            {
+                "name": "override_fan_target",
+                "count": 1,
+                "state": false,
+                "fans": ["fan3"],
+                "target": 11300
+            }
+        ]
+    },
+    {
+        // Hold fans at the given target when any critical service
+        // is not running for 5 seconds.
+        "name": "service(s) missing",
+        "groups": [
+            {
+                "name": "fan inventory",
+                "interface": "xyz.openbmc_project.Inventory.Item",
+                "property": { "name": "Present" }
+            },
+            {
+                "name": "occ objects",
+                "interface": "org.open_power.OCC.Status",
+                "property": { "name": "OccActive" }
+            },
+            {
+                "name": "nvme temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "planar temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "pcie cable card temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "ambient temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "altitude",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "signal",
+                "signal": "name_owner_changed"
+            },
+            {
+                "class": "init",
+                "method": "name_has_owner"
+            }
+        ],
+        "actions": [
+            {
+                "name": "call_actions_based_on_timer",
+                "timer": {
+                    "interval": 5000000,
+                    "type": "oneshot"
+                },
+                "actions": [
+                    {
+                        "name": "set_target_on_missing_owner",
+                        "groups": [
+                            {
+                                "name": "fan inventory",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property": { "name": "Present" }
+                            },
+                            {
+                                "name": "occ objects",
+                                "interface": "org.open_power.OCC.Status",
+                                "property": { "name": "OccActive" }
+                            },
+                            {
+                                "name": "nvme temps",
+                                "interface": "xyz.openbmc_project.Sensor.Value",
+                                "property": { "name": "Value" }
+                            },
+                            {
+                                "name": "planar temps",
+                                "interface": "xyz.openbmc_project.Sensor.Value",
+                                "property": { "name": "Value" }
+                            },
+                            {
+                                "name": "pcie cable card temps",
+                                "interface": "xyz.openbmc_project.Sensor.Value",
+                                "property": { "name": "Value" }
+                            },
+                            {
+                                "name": "ambient temp",
+                                "interface": "xyz.openbmc_project.Sensor.Value",
+                                "property": { "name": "Value" }
+                            }
+                        ],
+                        "target": 9700
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Force retry on the OCC status objects",
+        "groups": [
+            {
+                "name": "occ objects",
+                "interface": "org.open_power.OCC.Status",
+                "property": { "name": "OccActive" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "timer",
+                "type": "oneshot",
+                "interval": 30000000,
+                "preload_groups": true
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_target_on_missing_owner",
+                "groups": [
+                    {
+                        "name": "occ objects",
+                        "interface": "org.open_power.OCC.Status",
+                        "property": { "name": "OccActive" }
+                    }
+                ],
+                "target": 9700
+            }
+        ]
+    },
+    {
+        // Set a fan floor if an OCC isn't active
+        "name": "Non-active OCC(s)",
+        "groups": [
+            {
+                "name": "occ objects",
+                "interface": "org.open_power.OCC.Status",
+                "property": {
+                    "name": "OccActive"
+                }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            },
+            {
+                "class": "init",
+                "method": "get_properties"
+            }
+        ],
+        "actions": [
+            {
+                "name": "count_state_floor",
+                "count": 1,
+                "state": false,
+                "floor": 11300
+            }
+        ]
+    },
+    {
+        // Set a raised fan floor when any temperature or altitude sensor is
+        // nonfunctional
+        "name": "Nonfunctional temperature sensors",
+        "groups": [
+            {
+                "name": "proc0 core temps",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "proc1 core temps",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "proc2 core temps",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "proc3 core temps",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "proc4 core temps",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "proc5 core temps",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "proc6 core temps",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "proc7 core temps",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "proc0 ioring temp",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "proc1 ioring temp",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "proc2 ioring temp",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "proc3 ioring temp",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "proc4 ioring temp",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "proc5 ioring temp",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "proc6 ioring temp",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "proc7 ioring temp",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "dram temps",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "pmic temps",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "internal memory buffer temps",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "dram and external memory buffer temps",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "external memory buffer temps",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "vdd vrm temps",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "nvme temps",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "planar temps",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "pcie cable card temps",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "ambient temp",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "altitude",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_removed"
+            },
+            {
+                "class": "init",
+                "method": "get_properties"
+            }
+        ],
+        "actions": [
+            {
+                "name": "count_state_floor",
+                "count": 1,
+                "state": false,
+                "delay": 5,
+                "floor": 11300
+            }
+        ]
+    },
+    {
+        "name": "Set Proc 0 Core DVFS parameter",
+        "groups": [
+            {
+                "name": "proc 0 core dvfs temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_0_core_dvfs_increase_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 7
+                }
+            },
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_0_core_dvfs_decrease_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 9
+                }
+            }
+        ]
+    },
+    {
+        "name": "Set Proc 1 Core DVFS parameter",
+        "groups": [
+            {
+                "name": "proc 1 core dvfs temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_1_core_dvfs_increase_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 7
+                }
+            },
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_1_core_dvfs_decrease_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 9
+                }
+            }
+        ]
+    },
+    {
+        "name": "Set Proc 2 Core DVFS parameter",
+        "groups": [
+            {
+                "name": "proc 2 core dvfs temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_2_core_dvfs_increase_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 7
+                }
+            },
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_2_core_dvfs_decrease_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 9
+                }
+            }
+        ]
+    },
+    {
+        "name": "Set Proc 3 Core DVFS parameter",
+        "groups": [
+            {
+                "name": "proc 3 core dvfs temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_3_core_dvfs_increase_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 7
+                }
+            },
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_3_core_dvfs_decrease_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 9
+                }
+            }
+        ]
+    },
+    {
+        "name": "Set Proc 4 Core DVFS parameter",
+        "groups": [
+            {
+                "name": "proc 4 core dvfs temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_4_core_dvfs_increase_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 7
+                }
+            },
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_4_core_dvfs_decrease_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 9
+                }
+            }
+        ]
+    },
+    {
+        "name": "Set Proc 5 Core DVFS parameter",
+        "groups": [
+            {
+                "name": "proc 5 core dvfs temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_5_core_dvfs_increase_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 7
+                }
+            },
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_5_core_dvfs_decrease_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 9
+                }
+            }
+        ]
+    },
+    {
+        "name": "Set Proc 6 Core DVFS parameter",
+        "groups": [
+            {
+                "name": "proc 6 core dvfs temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_6_core_dvfs_increase_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 7
+                }
+            },
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_6_core_dvfs_decrease_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 9
+                }
+            }
+        ]
+    },
+    {
+        "name": "Set Proc 7 Core DVFS parameter",
+        "groups": [
+            {
+                "name": "proc 7 core dvfs temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_7_core_dvfs_increase_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 7
+                }
+            },
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_7_core_dvfs_decrease_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 9
+                }
+            }
+        ]
+    },
+    {
+        "name": "Set Proc 0 IO Ring DVFS parameter",
+        "groups": [
+            {
+                "name": "proc 0 ioring dvfs temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_0_ioring_dvfs_increase_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 10
+                }
+            },
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_0_ioring_dvfs_decrease_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 13
+                }
+            }
+        ]
+    },
+    {
+        "name": "Set Proc 1 IO Ring DVFS parameter",
+        "groups": [
+            {
+                "name": "proc 1 ioring dvfs temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_1_ioring_dvfs_increase_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 10
+                }
+            },
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_1_ioring_dvfs_decrease_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 13
+                }
+            }
+        ]
+    },
+    {
+        "name": "Set Proc 2 IO Ring DVFS parameter",
+        "groups": [
+            {
+                "name": "proc 2 ioring dvfs temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_2_ioring_dvfs_increase_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 10
+                }
+            },
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_2_ioring_dvfs_decrease_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 13
+                }
+            }
+        ]
+    },
+    {
+        "name": "Set Proc 3 IO Ring DVFS parameter",
+        "groups": [
+            {
+                "name": "proc 3 ioring dvfs temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_3_ioring_dvfs_increase_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 10
+                }
+            },
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_3_ioring_dvfs_decrease_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 13
+                }
+            }
+        ]
+    },
+    {
+        "name": "Set Proc 4 IO Ring DVFS parameter",
+        "groups": [
+            {
+                "name": "proc 4 ioring dvfs temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_4_ioring_dvfs_increase_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 10
+                }
+            },
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_4_ioring_dvfs_decrease_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 13
+                }
+            }
+        ]
+    },
+    {
+        "name": "Set Proc 5 IO Ring DVFS parameter",
+        "groups": [
+            {
+                "name": "proc 5 ioring dvfs temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_5_ioring_dvfs_increase_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 10
+                }
+            },
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_5_ioring_dvfs_decrease_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 13
+                }
+            }
+        ]
+    },
+    {
+        "name": "Set Proc 6 IO Ring DVFS parameter",
+        "groups": [
+            {
+                "name": "proc 6 ioring dvfs temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_6_ioring_dvfs_increase_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 10
+                }
+            },
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_6_ioring_dvfs_decrease_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 13
+                }
+            }
+        ]
+    },
+    {
+        "name": "Set Proc 7 IO Ring DVFS parameter",
+        "groups": [
+            {
+                "name": "proc 7 ioring dvfs temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_7_ioring_dvfs_increase_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 10
+                }
+            },
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_7_ioring_dvfs_decrease_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 13
+                }
+            }
+        ]
+    },
+    {
+        "name": "Set DRAM DVFS parameter",
+        "groups": [
+            {
+                "name": "dram dvfs temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "dram_dvfs_increase_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 8
+                }
+            },
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "dram_dvfs_decrease_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 11
+                }
+            }
+        ]
+    },
+    {
+        "name": "Set PMIC DVFS parameter",
+        "groups": [
+            {
+                "name": "pmic dvfs temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "pmic_dvfs_increase_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 10
+                }
+            },
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "pmic_dvfs_decrease_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 13
+                }
+            }
+        ]
+    },
+    {
+        "name": "Set internal memory buffer DVFS parameter",
+        "groups": [
+            {
+                "name": "internal memory buffer dvfs temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "intmb_dvfs_increase_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 11
+                }
+            },
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "intmb_dvfs_decrease_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 14
+                }
+            }
+        ]
+    },
+    {
+        "name": "Set DRAM and external memory buffer DVFS parameter",
+        "groups": [
+            {
+                "name": "dram and external memory buffer dvfs temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "dram_extmb_dvfs_increase_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 10
+                }
+            },
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "dram_extmb_dvfs_decrease_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 13
+                }
+            }
+        ]
+    },
+    {
+        "name": "Set external memory buffer DVFS parameter",
+        "groups": [
+            {
+                "name": "external memory buffer dvfs temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "extmb_dvfs_increase_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 10
+                }
+            },
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "extmb_dvfs_decrease_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 13
+                }
+            }
+        ]
+    },
+    {
+        // Collect group temperatures each iteration the repeating timer expires
+        "name": "Fan control timer loop",
+        "groups": [
+            {
+                "name": "proc0 core temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "proc1 core temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "proc2 core temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "proc3 core temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "proc4 core temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "proc5 core temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "proc6 core temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "proc7 core temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "proc0 ioring temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "proc1 ioring temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "proc2 ioring temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "proc3 ioring temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "proc4 ioring temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "proc5 ioring temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "proc6 ioring temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "proc7 ioring temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "dram temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "pmic temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "internal memory buffer temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "dram and external memory buffer temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "external memory buffer temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "vdd vrm temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "nvme temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "planar temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "pcie cable card temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "timer",
+                "type": "repeating",
+                "interval": 2000000,
+                "preload_groups": true
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "proc0 core temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_0_core_dvfs_increase_temp",
+                "delta": 255
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "proc1 core temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_1_core_dvfs_increase_temp",
+                "delta": 255
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "proc2 core temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_2_core_dvfs_increase_temp",
+                "delta": 255
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "proc3 core temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_3_core_dvfs_increase_temp",
+                "delta": 255
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "proc4 core temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_4_core_dvfs_increase_temp",
+                "delta": 255
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "proc5 core temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_5_core_dvfs_increase_temp",
+                "delta": 255
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "proc6 core temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_6_core_dvfs_increase_temp",
+                "delta": 255
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "proc7 core temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_7_core_dvfs_increase_temp",
+                "delta": 255
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "proc0 ioring temp",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_0_ioring_dvfs_increase_temp",
+                "delta": 255
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "proc1 ioring temp",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_1_ioring_dvfs_increase_temp",
+                "delta": 255
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "proc2 ioring temp",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_2_ioring_dvfs_increase_temp",
+                "delta": 255
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "proc3 ioring temp",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_3_ioring_dvfs_increase_temp",
+                "delta": 255
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "proc4 ioring temp",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_4_ioring_dvfs_increase_temp",
+                "delta": 255
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "proc5 ioring temp",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_5_ioring_dvfs_increase_temp",
+                "delta": 255
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "proc6 ioring temp",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_6_ioring_dvfs_increase_temp",
+                "delta": 255
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "proc7 ioring temp",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_7_ioring_dvfs_increase_temp",
+                "delta": 255
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "dram temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "dram_dvfs_increase_temp",
+                "delta": 175
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "pmic temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "pmic_dvfs_increase_temp",
+                "delta": 200
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "internal memory buffer temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "intmb_dvfs_increase_temp",
+                "delta": 200
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "dram and external memory buffer temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "dram_extmb_dvfs_increase_temp",
+                "delta": 200
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "external memory buffer temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "extmb_dvfs_increase_temp",
+                "delta": 200
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "vdd vrm temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state": 85.0,
+                "delta": 255
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "nvme temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state": 58.0,
+                "delta": 200
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "planar temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state": 50.0,
+                "delta": 255
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "pcie cable card temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state": 70.0,
+                "delta": 255
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "proc0 core temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_0_core_dvfs_decrease_temp",
+                "delta": 50
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "proc1 core temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_1_core_dvfs_decrease_temp",
+                "delta": 50
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "proc2 core temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_2_core_dvfs_decrease_temp",
+                "delta": 50
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "proc3 core temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_3_core_dvfs_decrease_temp",
+                "delta": 50
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "proc4 core temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_4_core_dvfs_decrease_temp",
+                "delta": 50
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "proc5 core temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_5_core_dvfs_decrease_temp",
+                "delta": 50
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "proc6 core temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_6_core_dvfs_decrease_temp",
+                "delta": 50
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "proc7 core temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_7_core_dvfs_decrease_temp",
+                "delta": 50
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "proc0 ioring temp",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_0_ioring_dvfs_decrease_temp",
+                "delta": 50
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "proc1 ioring temp",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_1_ioring_dvfs_decrease_temp",
+                "delta": 50
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "proc2 ioring temp",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_2_ioring_dvfs_decrease_temp",
+                "delta": 50
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "proc3 ioring temp",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_3_ioring_dvfs_decrease_temp",
+                "delta": 50
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "proc4 ioring temp",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_4_ioring_dvfs_decrease_temp",
+                "delta": 50
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "proc5 ioring temp",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_5_ioring_dvfs_decrease_temp",
+                "delta": 50
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "proc6 ioring temp",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_6_ioring_dvfs_decrease_temp",
+                "delta": 50
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "proc7 ioring temp",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_7_ioring_dvfs_decrease_temp",
+                "delta": 50
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "dram temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "dram_dvfs_decrease_temp",
+                "delta": 40
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "pmic temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "pmic_dvfs_decrease_temp",
+                "delta": 40
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "internal memory buffer temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "intmb_dvfs_decrease_temp",
+                "delta": 40
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "dram and external memory buffer temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "dram_extmb_dvfs_decrease_temp",
+                "delta": 40
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "external memory buffer temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "extmb_dvfs_decrease_temp",
+                "delta": 40
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "vdd vrm temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state": 80.0,
+                "delta": 30
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "nvme temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state": 55.0,
+                "delta": 40
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "planar temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state": 48.0,
+                "delta": 80
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "pcie cable card temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state": 65.0,
+                "delta": 80
+            }
+        ]
+    },
+    {
+        // Remove NVMe temperature objects from cache when they are removed from
+        // dbus. There's no need to react to their removal.
+        "name": "remove nvme objects",
+        "groups": [
+            {
+                "name": "nvme temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "nvme temps",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "signal",
+                "signal": "interfaces_removed"
+            }
+        ]
+    },
+    {
+        "name": "set pcie floor index",
+        "groups": [
+            {
+                "name": "pcie slots",
+                "interface": "xyz.openbmc_project.State.Decorator.PowerState",
+                "property": {
+                    "name": "PowerState"
+                }
+            },
+            {
+                "name": "pcie cards",
+                "interface": "xyz.openbmc_project.Inventory.Item.PCIeDevice",
+                "property": {
+                    "name": "Function0DeviceId"
+                }
+            },
+            {
+                "name": "pcie cards",
+                "interface": "xyz.openbmc_project.Inventory.Item.PCIeDevice",
+                "property": {
+                    "name": "Function0VendorId"
+                }
+            },
+            {
+                "name": "pcie cards",
+                "interface": "xyz.openbmc_project.Inventory.Item.PCIeDevice",
+                "property": {
+                    "name": "Function0SubsystemId"
+                }
+            },
+            {
+                "name": "pcie cards",
+                "interface": "xyz.openbmc_project.Inventory.Item.PCIeDevice",
+                "property": {
+                    "name": "Function0SubsystemVendorId"
+                }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            }
+        ],
+        "actions": [
+            {
+                "name": "pcie_card_floors",
+                "use_config_specific_files": true,
+                "settle_time": 2
+            }
+        ]
+    },
+    {
+        "name": "Set altitude offset parameter",
+        "groups": [
+            {
+                "name": "altitude",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            },
+            {
+                // Refresh altitude every 24hrs
+                "class": "timer",
+                "type": "repeating",
+                "interval": 86400000000,
+                "preload_groups": true
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "ambient_20_altitude_offset",
+                "modifier": {
+                    "operator": "less_than",
+                    "default_value": 1500,
+                    "value": [
+                        { "arg_value": 500, "parameter_value": 0 },
+                        { "arg_value": 1000, "parameter_value": 375 },
+                        { "arg_value": 1500, "parameter_value": 550 },
+                        { "arg_value": 2000, "parameter_value": 775 },
+                        { "arg_value": 2500, "parameter_value": 1000 },
+                        { "arg_value": 3050, "parameter_value": 1275 }
+                    ]
+                }
+            },
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "ambient_25_altitude_offset",
+                "modifier": {
+                    "operator": "less_than",
+                    "default_value": 2000,
+                    "value": [
+                        { "arg_value": 500, "parameter_value": 0 },
+                        { "arg_value": 1000, "parameter_value": 450 },
+                        { "arg_value": 1500, "parameter_value": 700 },
+                        { "arg_value": 2000, "parameter_value": 975 },
+                        { "arg_value": 2500, "parameter_value": 1275 },
+                        { "arg_value": 3050, "parameter_value": 1625 }
+                    ]
+                }
+            },
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "ambient_30_altitude_offset",
+                "modifier": {
+                    "operator": "less_than",
+                    "default_value": 2500,
+                    "value": [
+                        { "arg_value": 500, "parameter_value": 0 },
+                        { "arg_value": 1000, "parameter_value": 600 },
+                        { "arg_value": 1500, "parameter_value": 900 },
+                        { "arg_value": 2000, "parameter_value": 1275 },
+                        { "arg_value": 2500, "parameter_value": 1650 },
+                        { "arg_value": 3050, "parameter_value": 2100 }
+                    ]
+                }
+            },
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "ambient_35_altitude_offset",
+                "modifier": {
+                    "operator": "less_than",
+                    "default_value": 3000,
+                    "value": [
+                        { "arg_value": 500, "parameter_value": 0 },
+                        { "arg_value": 1000, "parameter_value": 750 },
+                        { "arg_value": 1500, "parameter_value": 1175 },
+                        { "arg_value": 2000, "parameter_value": 1625 },
+                        { "arg_value": 2500, "parameter_value": 2125 },
+                        { "arg_value": 3050, "parameter_value": 2725 }
+                    ]
+                }
+            },
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "ambient_40_altitude_offset",
+                "modifier": {
+                    "operator": "less_than",
+                    "default_value": 3500,
+                    "value": [
+                        { "arg_value": 500, "parameter_value": 0 },
+                        { "arg_value": 1000, "parameter_value": 975 },
+                        { "arg_value": 1500, "parameter_value": 1500 },
+                        { "arg_value": 2000, "parameter_value": 2100 },
+                        { "arg_value": 2500, "parameter_value": 2750 },
+                        { "arg_value": 3050, "parameter_value": 3500 }
+                    ]
+                }
+            }
+        ]
+    },
+    {
+        "name": "Fan floors",
+        "groups": [
+            {
+                "name": "ambient temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            },
+            {
+                "class": "parameter",
+                "parameter": "pcie_floor_index"
+            },
+            {
+                "class": "parameter",
+                "parameter": "ambient_20_altitude_offset"
+            },
+            {
+                "class": "parameter",
+                "parameter": "ambient_25_altitude_offset"
+            },
+            {
+                "class": "parameter",
+                "parameter": "ambient_30_altitude_offset"
+            },
+            {
+                "class": "parameter",
+                "parameter": "ambient_35_altitude_offset"
+            },
+            {
+                "class": "parameter",
+                "parameter": "ambient_40_altitude_offset"
+            }
+        ],
+        "actions": [
+            {
+                "name": "mapped_floor",
+                "key_group": "ambient temp",
+                "fan_floors": [
+                    {
+                        // Entry valid for temps < 20
+                        "key": 20,
+                        "default_floor": 3800,
+                        "floor_offset_parameter": "ambient_20_altitude_offset",
+                        "floors": [
+                            {
+                                "parameter": "pcie_floor_index",
+                                "floors": [
+                                    { "value": 1, "floor": 3800 },
+                                    { "value": 2, "floor": 4200 },
+                                    { "value": 3, "floor": 4600 },
+                                    { "value": 4, "floor": 6500 }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        // Entry valid for temps < 25
+                        "key": 25,
+                        "default_floor": 4400,
+                        "floor_offset_parameter": "ambient_25_altitude_offset",
+                        "floors": [
+                            {
+                                "parameter": "pcie_floor_index",
+                                "floors": [
+                                    { "value": 1, "floor": 4400 },
+                                    { "value": 2, "floor": 4800 },
+                                    { "value": 3, "floor": 5400 },
+                                    { "value": 4, "floor": 7500 }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        // Entry valid for temps < 30
+                        "key": 30,
+                        "default_floor": 5000,
+                        "floor_offset_parameter": "ambient_30_altitude_offset",
+                        "floors": [
+                            {
+                                "parameter": "pcie_floor_index",
+                                "floors": [
+                                    { "value": 1, "floor": 5000 },
+                                    { "value": 2, "floor": 5600 },
+                                    { "value": 3, "floor": 6500 },
+                                    { "value": 4, "floor": 9000 }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        // Entry valid for temps < 35
+                        "key": 35,
+                        "default_floor": 5800,
+                        "floor_offset_parameter": "ambient_35_altitude_offset",
+                        "floors": [
+                            {
+                                "parameter": "pcie_floor_index",
+                                "floors": [
+                                    { "value": 1, "floor": 5800 },
+                                    { "value": 2, "floor": 6700 },
+                                    { "value": 3, "floor": 7700 },
+                                    { "value": 4, "floor": 11300 }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        // Entry valid for temps < 40
+                        "key": 40,
+                        "default_floor": 6900,
+                        "floor_offset_parameter": "ambient_40_altitude_offset",
+                        "floors": [
+                            {
+                                "parameter": "pcie_floor_index",
+                                "floors": [
+                                    { "value": 1, "floor": 6900 },
+                                    { "value": 2, "floor": 7900 },
+                                    { "value": 3, "floor": 9200 },
+                                    { "value": 4, "floor": 11300 }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+]

--- a/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.Fuji/fans.json
+++ b/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.Fuji/fans.json
@@ -1,0 +1,26 @@
+[
+    {
+        "name": "fan0",
+        "zone": "0",
+        "sensors": ["fan0_0"],
+        "target_interface": "xyz.openbmc_project.Control.FanSpeed"
+    },
+    {
+        "name": "fan1",
+        "zone": "0",
+        "sensors": ["fan1_0"],
+        "target_interface": "xyz.openbmc_project.Control.FanSpeed"
+    },
+    {
+        "name": "fan2",
+        "zone": "0",
+        "sensors": ["fan2_0"],
+        "target_interface": "xyz.openbmc_project.Control.FanSpeed"
+    },
+    {
+        "name": "fan3",
+        "zone": "0",
+        "sensors": ["fan3_0"],
+        "target_interface": "xyz.openbmc_project.Control.FanSpeed"
+    }
+]

--- a/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.Fuji/groups.json
+++ b/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.Fuji/groups.json
@@ -1,0 +1,1012 @@
+[
+    {
+        "name": "fan inventory",
+        "members": [
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan0",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan1",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan2",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan3"
+        ]
+    },
+    {
+        "name": "fan0 rotor inventory",
+        "members": [
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan0/fan0_0",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan0/fan0_1"
+        ]
+    },
+    {
+        "name": "fan1 rotor inventory",
+        "members": [
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan1/fan1_0",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan1/fan1_1"
+        ]
+    },
+    {
+        "name": "fan2 rotor inventory",
+        "members": [
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan2/fan2_0",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan2/fan2_1"
+        ]
+    },
+    {
+        "name": "fan3 rotor inventory",
+        "members": [
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan3/fan3_0",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan3/fan3_1"
+        ]
+    },
+    {
+        "name": "occ objects",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/org/open_power/control/occ0",
+            "/org/open_power/control/occ1",
+            "/org/open_power/control/occ2",
+            "/org/open_power/control/occ3",
+            "/org/open_power/control/occ4",
+            "/org/open_power/control/occ5",
+            "/org/open_power/control/occ6",
+            "/org/open_power/control/occ7"
+        ]
+    },
+    {
+        "name": "proc0 core temps",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc0_core0_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core0_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core1_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core1_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core2_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core2_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core3_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core3_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core4_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core4_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core5_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core5_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core6_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core6_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core7_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core7_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core8_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core8_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core9_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core9_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core10_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core10_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core11_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core11_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core12_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core12_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core13_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core13_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core14_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core14_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core15_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core15_1_temp"
+        ]
+    },
+    {
+        "name": "proc1 core temps",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc1_core0_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core0_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core1_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core1_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core2_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core2_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core3_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core3_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core4_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core4_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core5_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core5_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core6_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core6_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core7_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core7_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core8_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core8_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core9_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core9_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core10_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core10_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core11_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core11_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core12_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core12_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core13_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core13_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core14_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core14_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core15_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core15_1_temp"
+        ]
+    },
+    {
+        "name": "proc2 core temps",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc2_core0_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core0_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core1_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core1_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core2_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core2_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core3_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core3_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core4_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core4_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core5_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core5_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core6_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core6_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core7_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core7_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core8_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core8_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core9_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core9_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core10_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core10_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core11_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core11_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core12_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core12_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core13_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core13_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core14_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core14_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core15_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core15_1_temp"
+        ]
+    },
+    {
+        "name": "proc3 core temps",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc3_core0_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core0_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core1_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core1_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core2_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core2_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core3_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core3_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core4_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core4_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core5_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core5_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core6_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core6_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core7_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core7_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core8_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core8_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core9_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core9_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core10_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core10_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core11_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core11_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core12_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core12_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core13_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core13_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core14_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core14_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core15_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core15_1_temp"
+        ]
+    },
+    {
+        "name": "proc4 core temps",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc4_core0_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc4_core0_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc4_core1_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc4_core1_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc4_core2_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc4_core2_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc4_core3_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc4_core3_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc4_core4_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc4_core4_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc4_core5_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc4_core5_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc4_core6_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc4_core6_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc4_core7_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc4_core7_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc4_core8_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc4_core8_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc4_core9_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc4_core9_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc4_core10_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc4_core10_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc4_core11_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc4_core11_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc4_core12_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc4_core12_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc4_core13_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc4_core13_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc4_core14_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc4_core14_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc4_core15_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc4_core15_1_temp"
+        ]
+    },
+    {
+        "name": "proc5 core temps",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc5_core0_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc5_core0_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc5_core1_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc5_core1_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc5_core2_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc5_core2_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc5_core3_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc5_core3_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc5_core4_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc5_core4_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc5_core5_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc5_core5_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc5_core6_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc5_core6_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc5_core7_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc5_core7_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc5_core8_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc5_core8_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc5_core9_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc5_core9_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc5_core10_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc5_core10_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc5_core11_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc5_core11_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc5_core12_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc5_core12_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc5_core13_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc5_core13_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc5_core14_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc5_core14_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc5_core15_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc5_core15_1_temp"
+        ]
+    },
+    {
+        "name": "proc6 core temps",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc6_core0_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc6_core0_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc6_core1_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc6_core1_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc6_core2_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc6_core2_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc6_core3_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc6_core3_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc6_core4_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc6_core4_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc6_core5_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc6_core5_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc6_core6_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc6_core6_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc6_core7_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc6_core7_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc6_core8_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc6_core8_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc6_core9_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc6_core9_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc6_core10_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc6_core10_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc6_core11_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc6_core11_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc6_core12_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc6_core12_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc6_core13_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc6_core13_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc6_core14_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc6_core14_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc6_core15_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc6_core15_1_temp"
+        ]
+    },
+    {
+        "name": "proc7 core temps",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc7_core0_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc7_core0_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc7_core1_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc7_core1_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc7_core2_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc7_core2_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc7_core3_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc7_core3_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc7_core4_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc7_core4_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc7_core5_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc7_core5_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc7_core6_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc7_core6_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc7_core7_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc7_core7_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc7_core8_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc7_core8_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc7_core9_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc7_core9_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc7_core10_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc7_core10_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc7_core11_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc7_core11_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc7_core12_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc7_core12_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc7_core13_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc7_core13_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc7_core14_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc7_core14_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc7_core15_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc7_core15_1_temp"
+        ]
+    },
+    {
+        "name": "proc0 ioring temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc0_ioring_temp"
+        ]
+    },
+    {
+        "name": "proc1 ioring temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc1_ioring_temp"
+        ]
+    },
+    {
+        "name": "proc2 ioring temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc2_ioring_temp"
+        ]
+    },
+    {
+        "name": "proc3 ioring temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc3_ioring_temp"
+        ]
+    },
+    {
+        "name": "proc4 ioring temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc4_ioring_temp"
+        ]
+    },
+    {
+        "name": "proc5 ioring temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc5_ioring_temp"
+        ]
+    },
+    {
+        "name": "proc6 ioring temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc6_ioring_temp"
+        ]
+    },
+    {
+        "name": "proc7 ioring temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc7_ioring_temp"
+        ]
+    },
+    {
+        "name": "dram temps",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/dimm0_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm1_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm2_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm3_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm4_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm5_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm6_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm7_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm8_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm9_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm10_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm11_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm12_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm13_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm14_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm15_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm16_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm17_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm18_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm19_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm20_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm21_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm22_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm23_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm24_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm25_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm26_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm27_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm28_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm29_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm30_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm31_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm32_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm33_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm34_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm35_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm36_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm37_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm38_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm39_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm40_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm41_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm42_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm43_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm44_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm45_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm46_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm47_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm48_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm49_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm50_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm51_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm52_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm53_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm54_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm55_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm56_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm57_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm58_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm59_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm60_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm61_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm62_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm63_dram_temp"
+        ]
+    },
+    {
+        "name": "dram dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/dimm_dram_dvfs_temp"
+        ]
+    },
+    {
+        "name": "pmic temps",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/dimm0_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm1_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm2_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm3_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm4_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm5_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm6_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm7_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm8_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm9_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm10_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm11_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm12_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm13_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm14_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm15_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm16_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm17_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm18_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm19_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm20_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm21_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm22_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm23_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm24_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm25_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm26_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm27_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm28_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm29_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm30_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm31_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm32_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm33_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm34_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm35_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm36_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm37_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm38_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm39_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm40_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm41_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm42_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm43_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm44_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm45_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm46_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm47_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm48_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm49_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm50_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm51_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm52_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm53_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm54_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm55_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm56_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm57_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm58_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm59_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm60_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm61_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm62_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm63_pmic_temp"
+        ]
+    },
+    {
+        "name": "pmic dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/dimm_pmic_dvfs_temp"
+        ]
+    },
+    {
+        "name": "internal memory buffer temps",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/dimm0_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm1_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm2_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm3_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm4_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm5_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm6_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm7_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm8_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm9_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm10_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm11_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm12_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm13_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm14_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm15_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm16_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm17_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm18_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm19_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm20_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm21_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm22_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm23_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm24_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm25_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm26_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm27_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm28_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm29_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm30_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm31_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm32_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm33_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm34_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm35_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm36_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm37_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm38_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm39_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm40_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm41_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm42_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm43_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm44_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm45_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm46_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm47_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm48_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm49_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm50_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm51_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm52_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm53_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm54_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm55_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm56_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm57_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm58_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm59_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm60_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm61_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm62_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm63_intmb_temp"
+        ]
+    },
+    {
+        "name": "internal memory buffer dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/dimm_intmb_dvfs_temp"
+        ]
+    },
+    {
+        // Repurposed as DRAM temperature sensors for 4U DDIMMs
+        "name": "dram and external memory buffer temps",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/dimm0_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm1_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm2_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm3_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm4_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm5_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm6_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm7_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm8_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm9_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm10_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm11_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm12_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm13_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm14_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm15_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm16_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm17_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm18_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm19_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm20_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm21_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm22_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm23_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm24_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm25_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm26_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm27_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm28_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm29_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm30_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm31_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm32_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm33_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm34_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm35_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm36_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm37_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm38_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm39_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm40_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm41_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm42_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm43_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm44_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm45_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm46_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm47_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm48_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm49_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm50_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm51_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm52_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm53_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm54_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm55_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm56_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm57_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm58_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm59_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm60_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm61_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm62_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm63_dram_extmb_temp"
+        ]
+    },
+    {
+        "name": "dram and external memory buffer dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/dimm_dram_extmb_dvfs_temp"
+        ]
+    },
+    {
+        // Repurposed as PMIC temperature sensors for 4U DDIMMs
+        "name": "external memory buffer temps",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/dimm0_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm1_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm2_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm3_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm4_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm5_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm6_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm7_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm8_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm9_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm10_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm11_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm12_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm13_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm14_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm15_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm16_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm17_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm18_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm19_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm20_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm21_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm22_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm23_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm24_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm25_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm26_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm27_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm28_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm29_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm30_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm31_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm32_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm33_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm34_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm35_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm36_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm37_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm38_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm39_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm40_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm41_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm42_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm43_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm44_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm45_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm46_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm47_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm48_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm49_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm50_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm51_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm52_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm53_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm54_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm55_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm56_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm57_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm58_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm59_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm60_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm61_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm62_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm63_extmb_temp"
+        ]
+    },
+    {
+        "name": "external memory buffer dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/dimm_extmb_dvfs_temp"
+        ]
+    },
+    {
+        "name": "vdd vrm temps",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/vrm_vdd0_temp",
+            "/xyz/openbmc_project/sensors/temperature/vrm_vdd1_temp",
+            "/xyz/openbmc_project/sensors/temperature/vrm_vdd2_temp",
+            "/xyz/openbmc_project/sensors/temperature/vrm_vdd3_temp",
+            "/xyz/openbmc_project/sensors/temperature/vrm_vdd4_temp",
+            "/xyz/openbmc_project/sensors/temperature/vrm_vdd5_temp",
+            "/xyz/openbmc_project/sensors/temperature/vrm_vdd6_temp",
+            "/xyz/openbmc_project/sensors/temperature/vrm_vdd7_temp"
+        ]
+    },
+    {
+        "name": "proc 0 core dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc0_core_dvfs_temp"
+        ]
+    },
+    {
+        "name": "proc 1 core dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc1_core_dvfs_temp"
+        ]
+    },
+    {
+        "name": "proc 2 core dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc2_core_dvfs_temp"
+        ]
+    },
+    {
+        "name": "proc 3 core dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc3_core_dvfs_temp"
+        ]
+    },
+    {
+        "name": "proc 4 core dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc4_core_dvfs_temp"
+        ]
+    },
+    {
+        "name": "proc 5 core dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc5_core_dvfs_temp"
+        ]
+    },
+    {
+        "name": "proc 6 core dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc6_core_dvfs_temp"
+        ]
+    },
+    {
+        "name": "proc 7 core dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc7_core_dvfs_temp"
+        ]
+    },
+    {
+        "name": "proc 0 ioring dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc0_ioring_dvfs_temp"
+        ]
+    },
+    {
+        "name": "proc 1 ioring dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc1_ioring_dvfs_temp"
+        ]
+    },
+    {
+        "name": "proc 2 ioring dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc2_ioring_dvfs_temp"
+        ]
+    },
+    {
+        "name": "proc 3 ioring dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc3_ioring_dvfs_temp"
+        ]
+    },
+    {
+        "name": "proc 4 ioring dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc4_ioring_dvfs_temp"
+        ]
+    },
+    {
+        "name": "proc 5 ioring dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc5_ioring_dvfs_temp"
+        ]
+    },
+    {
+        "name": "proc 6 ioring dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc6_ioring_dvfs_temp"
+        ]
+    },
+    {
+        "name": "proc 7 ioring dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc7_ioring_dvfs_temp"
+        ]
+    },
+    {
+        "name": "nvme temps",
+        "service": "xyz.openbmc_project.NVMeSensor",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/NVMe_1_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_2_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_3_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_4_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_5_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_6_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_7_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_8_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_9_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_10_Temp"
+        ]
+    },
+    {
+        "name": "planar temps",
+        "service": "xyz.openbmc_project.HwmonTempSensor",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/PCIE_0_Temp",
+            "/xyz/openbmc_project/sensors/temperature/PCIE_1_Temp"
+        ]
+    },
+    {
+        // Bear Lake card
+        "name": "pcie cable card temps",
+        "service": "xyz.openbmc_project.HwmonTempSensor",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/PCIe_Cable_Card_C1_Temp",
+            "/xyz/openbmc_project/sensors/temperature/PCIe_Cable_Card_C2_Temp",
+            "/xyz/openbmc_project/sensors/temperature/PCIe_Cable_Card_C3_Temp",
+            "/xyz/openbmc_project/sensors/temperature/PCIe_Cable_Card_C4_Temp",
+            "/xyz/openbmc_project/sensors/temperature/PCIe_Cable_Card_C5_Temp",
+            "/xyz/openbmc_project/sensors/temperature/PCIe_Cable_Card_C6_Temp",
+            "/xyz/openbmc_project/sensors/temperature/PCIe_Cable_Card_C7_Temp",
+            "/xyz/openbmc_project/sensors/temperature/PCIe_Cable_Card_C8_Temp",
+            "/xyz/openbmc_project/sensors/temperature/PCIe_Cable_Card_C9_Temp",
+            "/xyz/openbmc_project/sensors/temperature/PCIe_Cable_Card_C10_Temp",
+            "/xyz/openbmc_project/sensors/temperature/PCIe_Cable_Card_C11_Temp"
+        ]
+    },
+    {
+        "name": "ambient temp",
+        "service": "xyz.openbmc_project.VirtualSensor",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/Ambient_Virtual_Temp"
+        ]
+    },
+    {
+        "name": "altitude",
+        "service": "xyz.openbmc_project.VirtualSensor",
+        "members": ["/xyz/openbmc_project/sensors/altitude/Altitude"]
+    },
+    {
+        "name": "pcie cards",
+        "members": [
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot1/pcie_card1",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot2/pcie_card2",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot3/pcie_card3",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot4/pcie_card4",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot5/pcie_card5",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot6/pcie_card6",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot7/pcie_card7",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot8/pcie_card8",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot9/pcie_card9",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10/pcie_card10",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot11/pcie_card11"
+        ]
+    },
+    {
+        "name": "pcie slots",
+        "members": [
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot1",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot2",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot3",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot4",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot5",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot6",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot7",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot8",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot9",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot11"
+        ]
+    }
+]

--- a/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.Fuji/pcie_cards.json
+++ b/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.Fuji/pcie_cards.json
@@ -1,0 +1,148 @@
+{
+    "cards": [
+        {
+            "name": "PHYP had errors getting IDs",
+            "vendor_id": "0xFFFF",
+            "device_id": "0xFFFF",
+            "subsystem_vendor_id": "0xFFFF",
+            "subsystem_id": "0xFFFF",
+            "floor_index": 3
+        },
+        {
+            "name": "Bear Lake and Bear River",
+            "vendor_id": "0x1014",
+            "device_id": "0x04F2",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x0004",
+            "has_temp_sensor": true
+        },
+        {
+            "name": "GTO",
+            "vendor_id": "0x1014",
+            "device_id": "0x034A",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x033B",
+            "floor_index": 2
+        },
+        {
+            "name": "ZR1",
+            "vendor_id": "0x1014",
+            "device_id": "0x034A",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x035E",
+            "floor_index": 1
+        },
+        {
+            "name": "Z06",
+            "vendor_id": "0x1014",
+            "device_id": "0x034A",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x0355",
+            "floor_index": 2
+        },
+        {
+            "name": "Glacier Park EDR 2Port",
+            "vendor_id": "0x15B3",
+            "device_id": "0x1013",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x04F1",
+            "floor_index": 3
+        },
+        {
+            "name": "Glacier Park EDR 1Port",
+            "vendor_id": "0x15B3",
+            "device_id": "0x1013",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x04F4",
+            "floor_index": 3
+        },
+        {
+            "name": "Glacier Park EN 2Port",
+            "vendor_id": "0x15B3",
+            "device_id": "0x1013",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x04F7",
+            "floor_index": 1
+        },
+        {
+            "name": "Lassen Dual Port",
+            "vendor_id": "0x15B3",
+            "device_id": "0x1019",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x0617",
+            "floor_index": 3
+        },
+        {
+            "name": "Lassen Single Port",
+            "vendor_id": "0x15B3",
+            "device_id": "0x1017",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x0616",
+            "floor_index": 3
+        },
+        {
+            "name": "Everglades 10Gb 2Port",
+            "vendor_id": "0x15B3",
+            "device_id": "0x1015",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x061F",
+            "floor_index": 1
+        },
+        {
+            "name": "Everglades 25Gb 2Port",
+            "vendor_id": "0x15B3",
+            "device_id": "0x1015",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x061E",
+            "floor_index": 1
+        },
+        {
+            "name": "Haleakala EN 2Port 100Gb",
+            "vendor_id": "0x15B3",
+            "device_id": "0x1019",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x0635",
+            "floor_index": 4
+        },
+        {
+            "name": "Bono HMS",
+            "vendor_id": "0x1014",
+            "device_id": "0x04F2",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x0005",
+            "floor_index": 1
+        },
+        {
+            "name": "Cedar Lake 100G 2port",
+            "vendor_id": "0x15B3",
+            "device_id": "0x101D",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x06A6",
+            "floor_index": 4
+        },
+        {
+            "name": "Cedar Lake Crypto 100G 2port",
+            "vendor_id": "0x15B3",
+            "device_id": "0x101D",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x06A5",
+            "floor_index": 4
+        },
+        {
+            "name": "Castello",
+            "vendor_id": "0x1014",
+            "device_id": "0x0611",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x0611",
+            "floor_index": 3
+        },
+        {
+            "name": "Baby Blue Tip (CX-3 Pro)",
+            "vendor_id": "0x15B3",
+            "device_id": "0x1007",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x04E7",
+            "floor_index": 1
+        }
+    ]
+}

--- a/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.Fuji/zones.json
+++ b/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.Fuji/zones.json
@@ -1,0 +1,9 @@
+[
+    {
+        "name": "0",
+        "poweron_target": 11300,
+        "default_floor": 11300,
+        "increase_delay": 5,
+        "decrease_interval": 15
+    }
+]

--- a/monitor/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.Fuji/config.json
+++ b/monitor/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.Fuji/config.json
@@ -1,0 +1,135 @@
+{
+    "fans": [
+        {
+            "inventory": "/system/chassis/motherboard/fan0",
+            "method": "count",
+            "count_interval": 1,
+            "deviation": 15,
+            "num_sensors_nonfunc_for_fan_nonfunc": 0,
+            "monitor_start_delay": 30,
+            "fan_missing_error_delay": 20,
+            "nonfunc_rotor_error_delay": 0,
+            "set_func_on_present": true,
+            "sensors": [
+                {
+                    "name": "fan0_0",
+                    "threshold": 45,
+                    "has_target": true
+                },
+                {
+                    "name": "fan0_1",
+                    "threshold": 45,
+                    "has_target": false
+                }
+            ]
+        },
+        {
+            "inventory": "/system/chassis/motherboard/fan1",
+            "method": "count",
+            "count_interval": 1,
+            "deviation": 15,
+            "num_sensors_nonfunc_for_fan_nonfunc": 0,
+            "monitor_start_delay": 30,
+            "fan_missing_error_delay": 20,
+            "nonfunc_rotor_error_delay": 0,
+            "set_func_on_present": true,
+            "sensors": [
+                {
+                    "name": "fan1_0",
+                    "threshold": 45,
+                    "has_target": true
+                },
+                {
+                    "name": "fan1_1",
+                    "threshold": 45,
+                    "has_target": false
+                }
+            ]
+        },
+        {
+            "inventory": "/system/chassis/motherboard/fan2",
+            "method": "count",
+            "count_interval": 1,
+            "deviation": 15,
+            "num_sensors_nonfunc_for_fan_nonfunc": 0,
+            "monitor_start_delay": 30,
+            "fan_missing_error_delay": 20,
+            "nonfunc_rotor_error_delay": 0,
+            "set_func_on_present": true,
+            "sensors": [
+                {
+                    "name": "fan2_0",
+                    "threshold": 45,
+                    "has_target": true
+                },
+                {
+                    "name": "fan2_1",
+                    "threshold": 45,
+                    "has_target": false
+                }
+            ]
+        },
+        {
+            "inventory": "/system/chassis/motherboard/fan3",
+            "method": "count",
+            "count_interval": 1,
+            "deviation": 15,
+            "num_sensors_nonfunc_for_fan_nonfunc": 0,
+            "monitor_start_delay": 30,
+            "fan_missing_error_delay": 20,
+            "nonfunc_rotor_error_delay": 0,
+            "set_func_on_present": true,
+            "sensors": [
+                {
+                    "name": "fan3_0",
+                    "threshold": 45,
+                    "has_target": true
+                },
+                {
+                    "name": "fan3_1",
+                    "threshold": 45,
+                    "has_target": false
+                }
+            ]
+        }
+    ],
+    "sensor_trust_groups": [
+        {
+            "class": "NonzeroSpeed",
+            "group": [
+                {
+                    "name": "fan0_1"
+                },
+                {
+                    "name": "fan1_1"
+                },
+                {
+                    "name": "fan2_1"
+                },
+                {
+                    "name": "fan3_1"
+                }
+            ]
+        }
+    ],
+    "fault_handling": {
+        "num_nonfunc_rotors_before_error": 1,
+
+        "power_off_config": [
+            {
+                "type": "hard",
+                "cause": "missing_fan_frus",
+                "count": 1,
+                "delay": 25,
+                "state": "at_pgood"
+            },
+            {
+                "type": "epow",
+                "cause": "nonfunc_fan_rotors",
+                "count": 2,
+                "service_mode_delay": 150,
+                "meltdown_delay": 150
+            }
+        ]
+    }
+}

--- a/presence/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.Fuji/config.json
+++ b/presence/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.Fuji/config.json
@@ -1,0 +1,98 @@
+[
+    {
+        "name": "fan0",
+        "path": "/system/chassis/motherboard/fan0",
+        "methods": [
+            {
+                "type": "gpio",
+                "key": 15,
+                "physpath": "/sys/bus/i2c/devices/30-0061",
+                "devpath": "/dev/input/by-path/platform-gpio-keys-polled-event"
+            },
+            {
+                "type": "tach",
+                "sensors": ["fan0_0", "fan0_1"]
+            }
+        ],
+        "rpolicy": {
+            "type": "anyof"
+        },
+        "eeprom": {
+            "bus_address": "31-0050",
+            "driver_name": "at24",
+            "bind_delay_ms": 1000
+        }
+    },
+    {
+        "name": "fan1",
+        "path": "/system/chassis/motherboard/fan1",
+        "methods": [
+            {
+                "type": "gpio",
+                "key": 14,
+                "physpath": "/sys/bus/i2c/devices/30-0061",
+                "devpath": "/dev/input/by-path/platform-gpio-keys-polled-event"
+            },
+            {
+                "type": "tach",
+                "sensors": ["fan1_0", "fan1_1"]
+            }
+        ],
+        "rpolicy": {
+            "type": "anyof"
+        },
+        "eeprom": {
+            "bus_address": "32-0050",
+            "driver_name": "at24",
+            "bind_delay_ms": 1000
+        }
+    },
+    {
+        "name": "fan2",
+        "path": "/system/chassis/motherboard/fan2",
+        "methods": [
+            {
+                "type": "gpio",
+                "key": 13,
+                "physpath": "/sys/bus/i2c/devices/30-0061",
+                "devpath": "/dev/input/by-path/platform-gpio-keys-polled-event"
+            },
+            {
+                "type": "tach",
+                "sensors": ["fan2_0", "fan2_1"]
+            }
+        ],
+        "rpolicy": {
+            "type": "anyof"
+        },
+        "eeprom": {
+            "bus_address": "33-0050",
+            "driver_name": "at24",
+            "bind_delay_ms": 1000
+        }
+    },
+    {
+        "name": "fan3",
+        "path": "/system/chassis/motherboard/fan3",
+        "methods": [
+            {
+                "type": "gpio",
+                "key": 12,
+                "physpath": "/sys/bus/i2c/devices/30-0061",
+                "devpath": "/dev/input/by-path/platform-gpio-keys-polled-event"
+            },
+            {
+                "type": "tach",
+                "sensors": ["fan3_0", "fan3_1"]
+            }
+        ],
+        "rpolicy": {
+            "type": "anyof"
+        },
+        "eeprom": {
+            "bus_address": "34-0050",
+            "driver_name": "at24",
+            "bind_delay_ms": 1000
+        }
+    }
+]


### PR DESCRIPTION
#### configs:ibm: Fix DVFS Memory Throttling for Fuji
```
Currently, the Odyssey chip temperature on Fuji systems is reaching the
DVFS=91 C threshold, which is causing memory throttling issues. This
change introduces new JSON configuration files for Fuji systems based on
the Everest systems that makes the following changes in events.json.

intmb_dvfs_increase_temp: "value" changed from 9 to 11
intmb_dvfs_decrease_temp: "value" changed from 12 to 14
intmb_dvfs_increase_temp: "delta" changed from 150 to 200

This places the max temperature at 89 C, which provides a couple degrees
of margin to the DVFS throttle threshold.

Tested:
* Built firmware image and installed on Fuji system.
  Verified that new JSON files were present on system and
  loaded upon startup.
* Verified that the JSON changes to intmb_dvfs_increase_temp
  and intmb_dvfs_decrease_temp were reflected in the fan
  control parameters via fanctl query_dump. The
  intmb_dvfs_decrease_temp changed from 79.0 to 77.0 and
  the intmb_dvfs_increase_temp changed from 82.0 to 80.0.

Change-Id: If263a1232310571f8aa31321c743fafec5b51d44
Signed-off-by: Anwaar Hadi <anwaar.hadi@ibm.com>
```