### PR TITLE
1120: configs:ibm: Increase Count Threshold on BlueRidge (#68) & configs:ibm: Update Fuji Hot Adapters List (#67) & configs:ibm: Update Everest Hot Adapters List (#66)

### DIFF
--- a/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.Everest/pcie_cards.json
+++ b/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.Everest/pcie_cards.json
@@ -143,6 +143,46 @@
             "subsystem_vendor_id": "0x1014",
             "subsystem_id": "0x04E7",
             "floor_index": 1
+        },
+        {
+            "name": "Moso PCIe4 64Gb 2-port Fibre Channel Adapter",
+            "vendor_id": "0x1077",
+            "device_id": "0x2289",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x06C5",
+            "floor_index": 2
+        },
+        {
+            "name": "Dragonhead PCIe4 32Gb 4-port Fibre Channel Adapter",
+            "vendor_id": "0x1077",
+            "device_id": "0x2089",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x06C6",
+            "floor_index": 2
+        },
+        {
+            "name": "Shale 4 port ROCE adapter",
+            "vendor_id": "0x15B3",
+            "device_id": "0x1021",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x0712",
+            "floor_index": 2
+        },
+        {
+            "name": "Horton 32Gb 4-port Fibre Channel Adapter",
+            "vendor_id": "0x10DF",
+            "device_id": "0xF500",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x06C1",
+            "floor_index": 2
+        },
+        {
+            "name": "Nool 64Gb 2-port Fibre Channel Adapter",
+            "vendor_id": "0x10DF",
+            "device_id": "0xF500",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x06C2",
+            "floor_index": 2
         }
     ]
 }

--- a/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.Fuji/pcie_cards.json
+++ b/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.Fuji/pcie_cards.json
@@ -143,6 +143,54 @@
             "subsystem_vendor_id": "0x1014",
             "subsystem_id": "0x04E7",
             "floor_index": 1
+        },
+        {
+            "name": "Narwhal 2-port 200GbE x16 Gen5",
+            "vendor_id": "0x15B3",
+            "device_id": "0x1021",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x0714",
+            "floor_index": 4
+        },
+        {
+            "name": "Moso PCIe4 64Gb 2-port Fibre Channel Adapter",
+            "vendor_id": "0x1077",
+            "device_id": "0x2289",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x06C5",
+            "floor_index": 2
+        },
+        {
+            "name": "Dragonhead PCIe4 32Gb 4-port Fibre Channel Adapter",
+            "vendor_id": "0x1077",
+            "device_id": "0x2089",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x06C6",
+            "floor_index": 2
+        },
+        {
+            "name": "Shale 4 port ROCE adapter",
+            "vendor_id": "0x15B3",
+            "device_id": "0x1021",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x0712",
+            "floor_index": 2
+        },
+        {
+            "name": "Horton 32Gb 4-port Fibre Channel Adapter",
+            "vendor_id": "0x10DF",
+            "device_id": "0xF500",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x06C1",
+            "floor_index": 2
+        },
+        {
+            "name": "Nool 64Gb 2-port Fibre Channel Adapter",
+            "vendor_id": "0x10DF",
+            "device_id": "0xF500",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x06C2",
+            "floor_index": 2
         }
     ]
 }

--- a/monitor/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.BlueRidge2U/config.json
+++ b/monitor/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.BlueRidge2U/config.json
@@ -15,12 +15,12 @@
             "sensors": [
                 {
                     "name": "fan0_0",
-                    "threshold": 30,
+                    "threshold": 45,
                     "has_target": true
                 },
                 {
                     "name": "fan0_1",
-                    "threshold": 30,
+                    "threshold": 45,
                     "has_target": false,
                     "factor": 0.79,
                     "offset": 100
@@ -40,12 +40,12 @@
             "sensors": [
                 {
                     "name": "fan1_0",
-                    "threshold": 30,
+                    "threshold": 45,
                     "has_target": true
                 },
                 {
                     "name": "fan1_1",
-                    "threshold": 30,
+                    "threshold": 45,
                     "has_target": false,
                     "factor": 0.79,
                     "offset": 100
@@ -65,12 +65,12 @@
             "sensors": [
                 {
                     "name": "fan2_0",
-                    "threshold": 30,
+                    "threshold": 45,
                     "has_target": true
                 },
                 {
                     "name": "fan2_1",
-                    "threshold": 30,
+                    "threshold": 45,
                     "has_target": false,
                     "factor": 0.79,
                     "offset": 100
@@ -90,12 +90,12 @@
             "sensors": [
                 {
                     "name": "fan3_0",
-                    "threshold": 30,
+                    "threshold": 45,
                     "has_target": true
                 },
                 {
                     "name": "fan3_1",
-                    "threshold": 30,
+                    "threshold": 45,
                     "has_target": false,
                     "factor": 0.79,
                     "offset": 100
@@ -115,12 +115,12 @@
             "sensors": [
                 {
                     "name": "fan4_0",
-                    "threshold": 30,
+                    "threshold": 45,
                     "has_target": true
                 },
                 {
                     "name": "fan4_1",
-                    "threshold": 30,
+                    "threshold": 45,
                     "has_target": false,
                     "factor": 0.79,
                     "offset": 100
@@ -140,12 +140,12 @@
             "sensors": [
                 {
                     "name": "fan5_0",
-                    "threshold": 30,
+                    "threshold": 45,
                     "has_target": true
                 },
                 {
                     "name": "fan5_1",
-                    "threshold": 30,
+                    "threshold": 45,
                     "has_target": false,
                     "factor": 0.79,
                     "offset": 100


### PR DESCRIPTION
#### configs:ibm: Increase Count Threshold on BlueRidge (#68)
```
Increase the out of range count threshold in the fan monitor
config on BlueRidge 2U systems from 30 to 45. This will give
the fans more time to get to their target speed.

Tested:
* Copied config file to BlueRidge 2U system and ensured that
  no errors were produced.
* Verified that fanctl query_dump output was consistent with
  JSON changes made.

Change-Id: I597b4077f64f6b920f65459d60f5e256efe5e9f8

Signed-off-by: Anwaar Hadi <anwaar.hadi@ibm.com>```
#### configs:ibm: Update Fuji Hot Adapters List (#67)
```
Update the hot adapters list in the pcie_cards.json config file
for Fuji systems.

Tested:
* Ran local CI unit tests and verified they passed.
* Built repo in bitbake and ensured change was present in
  build output.
* Copied config file to Fuji system and ensured that the
  flight recorder output in fanctl query_dump was consistent
  with the JSON changes made.

Change-Id: I9c4cd9f260950fae3d3b1b59a38e27c819c24179

Signed-off-by: Anwaar Hadi <anwaar.hadi@ibm.com>```
#### configs:ibm: Update Everest Hot Adapters List (#66)
```
Update the hot adapters list in the pcie_cards.json config file
for Everest systems.

Tested:
* Ran local CI unit tests and verified they passed.
* Built repo in bitbake and ensured change was present in
  build output.

Change-Id: I3e42eac4fc7bfcbeb53fd337e9dd54197dfe06af

Signed-off-by: Anwaar Hadi <anwaar.hadi@ibm.com>```