### PR TITLE
Vanguard PCIe Hot Adapter Config for BlueRidge and Fuji

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,26 +27,22 @@ file(s) at runtime.
 The following applications are built by default:
 
 - [Fan Control](#fan-control)
-
   - To disable from building, use the `-Dcontrol-service=disabled` meson option:
 
     meson build -Dcontrol-service=disabled
 
 - [Fan Presence Detection](#fan-presence-detection)
-
   - To disable from building, use the `-Dpresence-service=disabled` meson
     option:
 
     meson build -Dpresence-service=disabled
 
 - [Fan Monitoring](#fan-monitoring)
-
   - To disable from building, use the `-Dmonitor-service=disabled` meson option:
 
     meson build -Dmonitor-service=disabled
 
 - [Sensor Monitoring](#sensor-monitoring)
-
   - To disable from building, use the `-Dsensor-monitor-service=disabled` meson
     option:
 
@@ -55,7 +51,6 @@ The following applications are built by default:
 The following applications must be enabled at _configure_ time to be built:
 
 - [Cooling Type](#cooling-type)
-
   - To enable building this, set the `-Dcooling-type-service=enable` meson
     option:
 

--- a/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.BlueRidge/fans.json
+++ b/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.BlueRidge/fans.json
@@ -1,0 +1,38 @@
+[
+    {
+        "name": "fan0",
+        "zone": "0",
+        "sensors": ["fan0_0"],
+        "target_interface": "xyz.openbmc_project.Control.FanSpeed"
+    },
+    {
+        "name": "fan1",
+        "zone": "0",
+        "sensors": ["fan1_0"],
+        "target_interface": "xyz.openbmc_project.Control.FanSpeed"
+    },
+    {
+        "name": "fan2",
+        "zone": "0",
+        "sensors": ["fan2_0"],
+        "target_interface": "xyz.openbmc_project.Control.FanSpeed"
+    },
+    {
+        "name": "fan3",
+        "zone": "0",
+        "sensors": ["fan3_0"],
+        "target_interface": "xyz.openbmc_project.Control.FanSpeed"
+    },
+    {
+        "name": "fan4",
+        "zone": "0",
+        "sensors": ["fan4_0"],
+        "target_interface": "xyz.openbmc_project.Control.FanSpeed"
+    },
+    {
+        "name": "fan5",
+        "zone": "0",
+        "sensors": ["fan5_0"],
+        "target_interface": "xyz.openbmc_project.Control.FanSpeed"
+    }
+]

--- a/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.BlueRidge1S4U/events.json
+++ b/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.BlueRidge1S4U/events.json
@@ -1,0 +1,1464 @@
+[
+    {
+        // Hold fans at the given target when a number of fans are missing.
+        "name": "fan(s) missing",
+        "groups": [
+            {
+                "name": "fan inventory",
+                "interface": "xyz.openbmc_project.Inventory.Item",
+                "property": { "name": "Present" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            }
+        ],
+        "actions": [
+            {
+                "name": "count_state_before_target",
+                "count": 1,
+                "state": false,
+                "target": 10400
+            }
+        ]
+    },
+    {
+        // Hold fans at the given target when a number of rotors are nonfunctional.
+        "name": "fan rotor(s) faulted",
+        "groups": [
+            {
+                "name": "fan0 rotor inventory",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "fan1 rotor inventory",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "fan2 rotor inventory",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "fan4 rotor inventory",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            }
+        ],
+        "actions": [
+            {
+                "name": "count_state_before_target",
+                "count": 1,
+                "state": false,
+                "target": 10400
+            }
+        ]
+    },
+    {
+        // Hold fans at the given target when any critical service
+        // is not running for 5 seconds.
+        "name": "service(s) missing",
+        "groups": [
+            {
+                "name": "fan inventory",
+                "interface": "xyz.openbmc_project.Inventory.Item",
+                "property": { "name": "Present" }
+            },
+            {
+                "name": "occ objects",
+                "interface": "org.open_power.OCC.Status",
+                "property": { "name": "OccActive" }
+            },
+            {
+                "name": "nvme temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "planar temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "flett temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "pcie cable card temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "ambient temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "signal",
+                "signal": "name_owner_changed"
+            },
+            {
+                "class": "init",
+                "method": "name_has_owner"
+            }
+        ],
+        "actions": [
+            {
+                "name": "call_actions_based_on_timer",
+                "timer": {
+                    "interval": 5000000,
+                    "type": "oneshot"
+                },
+                "actions": [
+                    {
+                        "name": "set_target_on_missing_owner",
+                        "groups": [
+                            {
+                                "name": "fan inventory",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property": { "name": "Present" }
+                            },
+                            {
+                                "name": "occ objects",
+                                "interface": "org.open_power.OCC.Status",
+                                "property": { "name": "OccActive" }
+                            },
+                            {
+                                "name": "nvme temps",
+                                "interface": "xyz.openbmc_project.Sensor.Value",
+                                "property": { "name": "Value" }
+                            },
+                            {
+                                "name": "planar temps",
+                                "interface": "xyz.openbmc_project.Sensor.Value",
+                                "property": { "name": "Value" }
+                            },
+                            {
+                                "name": "flett temps",
+                                "interface": "xyz.openbmc_project.Sensor.Value",
+                                "property": { "name": "Value" }
+                            },
+                            {
+                                "name": "pcie cable card temps",
+                                "interface": "xyz.openbmc_project.Sensor.Value",
+                                "property": { "name": "Value" }
+                            },
+                            {
+                                "name": "ambient temp",
+                                "interface": "xyz.openbmc_project.Sensor.Value",
+                                "property": { "name": "Value" }
+                            }
+                        ],
+                        "target": 10400
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Force retry on the OCC status objects",
+        "groups": [
+            {
+                "name": "occ objects",
+                "interface": "org.open_power.OCC.Status",
+                "property": { "name": "OccActive" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "timer",
+                "type": "oneshot",
+                "interval": 30000000,
+                "preload_groups": true
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_target_on_missing_owner",
+                "groups": [
+                    {
+                        "name": "occ objects",
+                        "interface": "org.open_power.OCC.Status",
+                        "property": { "name": "OccActive" }
+                    }
+                ],
+                "target": 10400
+            }
+        ]
+    },
+    {
+        // Set a fan floor if an OCC isn't active
+        "name": "Non-active OCC(s)",
+        "groups": [
+            {
+                "name": "occ objects",
+                "interface": "org.open_power.OCC.Status",
+                "property": {
+                    "name": "OccActive"
+                }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            },
+            {
+                "class": "init",
+                "method": "get_properties"
+            }
+        ],
+        "actions": [
+            {
+                "name": "count_state_floor",
+                "count": 1,
+                "state": false,
+                "floor": 10400
+            }
+        ]
+    },
+    {
+        // Set a raised fan floor when any temperature sensor is nonfunctional
+        "name": "Nonfunctional temperature sensors",
+        "groups": [
+            {
+                "name": "proc0 core temps",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "proc1 core temps",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "proc0 ioring temp",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "proc1 ioring temp",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "dram temps",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "pmic temps",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "internal memory buffer temps",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "dram and external memory buffer temps",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "external memory buffer temps",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "vdd vrm temps",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "nvme temps",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "planar temps",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "flett temps",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "pcie cable card temps",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "ambient temp",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_removed"
+            },
+            {
+                "class": "init",
+                "method": "get_properties"
+            }
+        ],
+        "actions": [
+            {
+                "name": "count_state_floor",
+                "count": 1,
+                "state": false,
+                "delay": 5,
+                "floor": 10400
+            }
+        ]
+    },
+    {
+        "name": "Set Proc 0 Core DVFS parameter",
+        "groups": [
+            {
+                "name": "proc 0 core dvfs temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_0_core_dvfs_increase_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 10
+                }
+            },
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_0_core_dvfs_decrease_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 13
+                }
+            }
+        ]
+    },
+    {
+        "name": "Set Proc 1 Core DVFS parameter",
+        "groups": [
+            {
+                "name": "proc 1 core dvfs temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_1_core_dvfs_increase_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 10
+                }
+            },
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_1_core_dvfs_decrease_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 13
+                }
+            }
+        ]
+    },
+    {
+        "name": "Set Proc 0 IO Ring DVFS parameter",
+        "groups": [
+            {
+                "name": "proc 0 ioring dvfs temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_0_ioring_dvfs_increase_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 10
+                }
+            },
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_0_ioring_dvfs_decrease_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 13
+                }
+            }
+        ]
+    },
+    {
+        "name": "Set Proc 1 IO Ring DVFS parameter",
+        "groups": [
+            {
+                "name": "proc 1 ioring dvfs temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_1_ioring_dvfs_increase_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 10
+                }
+            },
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_1_ioring_dvfs_decrease_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 13
+                }
+            }
+        ]
+    },
+    {
+        "name": "Set DRAM DVFS parameter",
+        "groups": [
+            {
+                "name": "dram dvfs temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "dram_dvfs_increase_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 10
+                }
+            },
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "dram_dvfs_decrease_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 13
+                }
+            }
+        ]
+    },
+    {
+        "name": "Set PMIC DVFS parameter",
+        "groups": [
+            {
+                "name": "pmic dvfs temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "pmic_dvfs_increase_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 10
+                }
+            },
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "pmic_dvfs_decrease_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 13
+                }
+            }
+        ]
+    },
+    {
+        "name": "Set internal memory buffer DVFS parameter",
+        "groups": [
+            {
+                "name": "internal memory buffer dvfs temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "intmb_dvfs_increase_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 10
+                }
+            },
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "intmb_dvfs_decrease_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 13
+                }
+            }
+        ]
+    },
+    {
+        "name": "Set DRAM and external memory buffer DVFS parameter",
+        "groups": [
+            {
+                "name": "dram and external memory buffer dvfs temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "dram_extmb_dvfs_increase_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 10
+                }
+            },
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "dram_extmb_dvfs_decrease_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 13
+                }
+            }
+        ]
+    },
+    {
+        "name": "Set external memory buffer DVFS parameter",
+        "groups": [
+            {
+                "name": "external memory buffer dvfs temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "extmb_dvfs_increase_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 7
+                }
+            },
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "extmb_dvfs_decrease_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 10
+                }
+            }
+        ]
+    },
+    {
+        // Collect group temperatures each iteration the repeating timer expires
+        "name": "Fan control timer loop",
+        "groups": [
+            {
+                "name": "proc0 core temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "proc1 core temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "proc0 ioring temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "proc1 ioring temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "dram temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "pmic temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "internal memory buffer temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "dram and external memory buffer temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "external memory buffer temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "vdd vrm temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "nvme temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "planar temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "flett temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "pcie cable card temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "timer",
+                "type": "repeating",
+                "interval": 2000000,
+                "preload_groups": true
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "proc0 core temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_0_core_dvfs_increase_temp",
+                "delta": 300
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "proc1 core temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_1_core_dvfs_increase_temp",
+                "delta": 300
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "proc0 ioring temp",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_0_ioring_dvfs_increase_temp",
+                "delta": 300
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "proc1 ioring temp",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_1_ioring_dvfs_increase_temp",
+                "delta": 300
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "dram temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "dram_dvfs_increase_temp",
+                "delta": 200
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "pmic temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "pmic_dvfs_increase_temp",
+                "delta": 200
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "internal memory buffer temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "intmb_dvfs_increase_temp",
+                "delta": 200
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "dram and external memory buffer temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "dram_extmb_dvfs_increase_temp",
+                "delta": 200
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "external memory buffer temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "extmb_dvfs_increase_temp",
+                "delta": 200
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "vdd vrm temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state": 82.0,
+                "delta": 300
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "nvme temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state": 58.0,
+                "delta": 200
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "planar temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state": 65.0,
+                "delta": 255
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "flett temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state": 80.0,
+                "delta": 200
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "pcie cable card temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state": 70.0,
+                "delta": 255
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "proc0 core temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_0_core_dvfs_decrease_temp",
+                "delta": 50
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "proc1 core temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_1_core_dvfs_decrease_temp",
+                "delta": 50
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "proc0 ioring temp",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_0_ioring_dvfs_decrease_temp",
+                "delta": 50
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "proc1 ioring temp",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_1_ioring_dvfs_decrease_temp",
+                "delta": 50
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "dram temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "dram_dvfs_decrease_temp",
+                "delta": 50
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "pmic temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "pmic_dvfs_decrease_temp",
+                "delta": 50
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "internal memory buffer temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "intmb_dvfs_decrease_temp",
+                "delta": 50
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "dram and external memory buffer temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "dram_extmb_dvfs_decrease_temp",
+                "delta": 50
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "external memory buffer temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "extmb_dvfs_decrease_temp",
+                "delta": 50
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "vdd vrm temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state": 79.0,
+                "delta": 50
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "nvme temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state": 55.0,
+                "delta": 50
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "planar temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state": 60.0,
+                "delta": 50
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "flett temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state": 75.0,
+                "delta": 40
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "pcie cable card temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state": 65.0,
+                "delta": 50
+            }
+        ]
+    },
+    {
+        // Remove NVMe temperature objects from cache when they are removed from
+        // dbus. There's no need to react to their removal.
+        "name": "remove nvme objects",
+        "groups": [
+            {
+                "name": "nvme temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "nvme temps",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "signal",
+                "signal": "interfaces_removed"
+            }
+        ]
+    },
+    {
+        "name": "set pcie floor index",
+        "groups": [
+            {
+                "name": "pcie slots",
+                "interface": "xyz.openbmc_project.State.Decorator.PowerState",
+                "property": {
+                    "name": "PowerState"
+                }
+            },
+            {
+                "name": "pcie cards",
+                "interface": "xyz.openbmc_project.Inventory.Item.PCIeDevice",
+                "property": {
+                    "name": "Function0DeviceId"
+                }
+            },
+            {
+                "name": "pcie cards",
+                "interface": "xyz.openbmc_project.Inventory.Item.PCIeDevice",
+                "property": {
+                    "name": "Function0VendorId"
+                }
+            },
+            {
+                "name": "pcie cards",
+                "interface": "xyz.openbmc_project.Inventory.Item.PCIeDevice",
+                "property": {
+                    "name": "Function0SubsystemId"
+                }
+            },
+            {
+                "name": "pcie cards",
+                "interface": "xyz.openbmc_project.Inventory.Item.PCIeDevice",
+                "property": {
+                    "name": "Function0SubsystemVendorId"
+                }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            }
+        ],
+        "actions": [
+            {
+                "name": "pcie_card_floors",
+                "use_config_specific_files": true,
+                "settle_time": 2
+            }
+        ]
+    },
+    {
+        "name": "Set altitude offset parameter",
+        "groups": [
+            {
+                "name": "altitude",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            },
+            {
+                // Refresh altitude every 24hrs
+                "class": "timer",
+                "type": "repeating",
+                "interval": 86400000000,
+                "preload_groups": true
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "altitude_offset",
+                "modifier": {
+                    "operator": "less_than",
+                    "default_value": 3000,
+                    "value": [
+                        { "arg_value": 1000, "parameter_value": 0 },
+                        { "arg_value": 1900, "parameter_value": 1000 },
+                        { "arg_value": 2800, "parameter_value": 2000 }
+                    ]
+                }
+            }
+        ]
+    },
+    {
+        "name": "Fan floors",
+        "groups": [
+            {
+                "name": "ambient temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "cpu 0 inventory",
+                "interface": "xyz.openbmc_project.Inventory.Decorator.Asset",
+                "property": { "name": "Model" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            },
+            {
+                "class": "parameter",
+                "parameter": "pcie_floor_index"
+            },
+            {
+                "class": "parameter",
+                "parameter": "altitude_offset"
+            }
+        ],
+        "actions": [
+            {
+                "name": "mapped_floor",
+                "key_group": "ambient temp",
+                "condition_group": "cpu 0 inventory",
+                "condition_value": "5CF9",
+                "condition_op": "not_equal",
+                "fan_floors": [
+                    {
+                        // Entry valid for ambient temp < 27
+                        "key": 27,
+                        "default_floor": 3700,
+                        "floor_offset_parameter": "altitude_offset",
+                        "floors": [
+                            {
+                                "parameter": "pcie_floor_index",
+                                "floors": [
+                                    { "value": 1, "floor": 6000 },
+                                    { "value": 2, "floor": 7000 },
+                                    { "value": 3, "floor": 8000 }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        // Entry valid for ambient temp < 32
+                        "key": 32,
+                        "default_floor": 5000,
+                        "floor_offset_parameter": "altitude_offset",
+                        "floors": [
+                            {
+                                "parameter": "pcie_floor_index",
+                                "floors": [
+                                    { "value": 1, "floor": 7000 },
+                                    { "value": 2, "floor": 9000 },
+                                    { "value": 3, "floor": 9500 }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        // Entry valid for ambient temp < 37
+                        "key": 37,
+                        "default_floor": 6000,
+                        "floor_offset_parameter": "altitude_offset",
+                        "floors": [
+                            {
+                                "parameter": "pcie_floor_index",
+                                "floors": [
+                                    { "value": 1, "floor": 9000 },
+                                    { "value": 2, "floor": 9500 },
+                                    { "value": 3, "floor": 10400 }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        // Entry valid for ambient temp < 42
+                        "key": 42,
+                        "default_floor": 8000,
+                        "floor_offset_parameter": "altitude_offset",
+                        "floors": [
+                            {
+                                "parameter": "pcie_floor_index",
+                                "floors": [
+                                    { "value": 1, "floor": 9500 },
+                                    { "value": 2, "floor": 10400 },
+                                    { "value": 3, "floor": 10400 }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "name": "mapped_floor",
+                "key_group": "ambient temp",
+                "condition_group": "cpu 0 inventory",
+                "condition_value": "5CF9",
+                "condition_op": "equal",
+                "fan_floors": [
+                    {
+                        // Entry valid for ambient temp < 27
+                        "key": 27,
+                        "default_floor": 5000,
+                        "floor_offset_parameter": "altitude_offset",
+                        "floors": [
+                            {
+                                "parameter": "pcie_floor_index",
+                                "floors": [
+                                    { "value": 1, "floor": 7000 },
+                                    { "value": 2, "floor": 8000 },
+                                    { "value": 3, "floor": 9000 }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        // Entry valid for ambient temp < 32
+                        "key": 32,
+                        "default_floor": 6000,
+                        "floor_offset_parameter": "altitude_offset",
+                        "floors": [
+                            {
+                                "parameter": "pcie_floor_index",
+                                "floors": [
+                                    { "value": 1, "floor": 8000 },
+                                    { "value": 2, "floor": 9000 },
+                                    { "value": 3, "floor": 9500 }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        // Entry valid for ambient temp < 37
+                        "key": 37,
+                        "default_floor": 7000,
+                        "floor_offset_parameter": "altitude_offset",
+                        "floors": [
+                            {
+                                "parameter": "pcie_floor_index",
+                                "floors": [
+                                    { "value": 1, "floor": 9000 },
+                                    { "value": 2, "floor": 9500 },
+                                    { "value": 3, "floor": 10400 }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        // Entry valid for ambient temp < 42
+                        "key": 42,
+                        "default_floor": 8000,
+                        "floor_offset_parameter": "altitude_offset",
+                        "floors": [
+                            {
+                                "parameter": "pcie_floor_index",
+                                "floors": [
+                                    { "value": 1, "floor": 9500 },
+                                    { "value": 2, "floor": 10400 },
+                                    { "value": 3, "floor": 10400 }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+]

--- a/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.BlueRidge1S4U/fans.json
+++ b/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.BlueRidge1S4U/fans.json
@@ -1,0 +1,26 @@
+[
+    {
+        "name": "fan0",
+        "zone": "0",
+        "sensors": ["fan0_0"],
+        "target_interface": "xyz.openbmc_project.Control.FanSpeed"
+    },
+    {
+        "name": "fan1",
+        "zone": "0",
+        "sensors": ["fan1_0"],
+        "target_interface": "xyz.openbmc_project.Control.FanSpeed"
+    },
+    {
+        "name": "fan2",
+        "zone": "0",
+        "sensors": ["fan2_0"],
+        "target_interface": "xyz.openbmc_project.Control.FanSpeed"
+    },
+    {
+        "name": "fan4",
+        "zone": "0",
+        "sensors": ["fan4_0"],
+        "target_interface": "xyz.openbmc_project.Control.FanSpeed"
+    }
+]

--- a/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.BlueRidge1S4U/groups.json
+++ b/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.BlueRidge1S4U/groups.json
@@ -1,0 +1,414 @@
+[
+    {
+        "name": "fan inventory",
+        "members": [
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan0",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan1",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan2",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan4"
+        ]
+    },
+    {
+        "name": "fan0 rotor inventory",
+        "members": [
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan0/fan0_0"
+        ]
+    },
+    {
+        "name": "fan1 rotor inventory",
+        "members": [
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan1/fan1_0"
+        ]
+    },
+    {
+        "name": "fan2 rotor inventory",
+        "members": [
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan2/fan2_0"
+        ]
+    },
+    {
+        "name": "fan4 rotor inventory",
+        "members": [
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan4/fan4_0"
+        ]
+    },
+    {
+        "name": "cpu 0 inventory",
+        "members": [
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0"
+        ]
+    },
+    {
+        "name": "occ objects",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/org/open_power/control/occ0",
+            "/org/open_power/control/occ1"
+        ]
+    },
+    {
+        "name": "proc0 core temps",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc0_core0_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core0_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core1_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core1_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core2_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core2_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core3_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core3_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core4_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core4_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core5_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core5_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core6_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core6_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core7_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core7_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core8_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core8_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core9_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core9_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core10_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core10_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core11_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core11_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core12_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core12_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core13_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core13_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core14_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core14_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core15_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core15_1_temp"
+        ]
+    },
+    {
+        "name": "proc1 core temps",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc1_core0_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core0_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core1_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core1_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core2_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core2_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core3_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core3_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core4_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core4_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core5_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core5_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core6_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core6_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core7_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core7_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core8_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core8_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core9_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core9_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core10_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core10_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core11_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core11_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core12_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core12_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core13_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core13_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core14_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core14_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core15_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core15_1_temp"
+        ]
+    },
+    {
+        "name": "proc0 ioring temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc0_ioring_temp"
+        ]
+    },
+    {
+        "name": "proc1 ioring temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc1_ioring_temp"
+        ]
+    },
+    {
+        "name": "dram temps",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/dimm0_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm1_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm2_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm3_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm4_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm5_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm6_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm7_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm8_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm9_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm10_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm11_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm12_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm13_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm14_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm15_dram_temp"
+        ]
+    },
+    {
+        "name": "dram dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/dimm_dram_dvfs_temp"
+        ]
+    },
+    {
+        "name": "pmic temps",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/dimm0_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm1_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm2_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm3_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm4_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm5_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm6_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm7_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm8_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm9_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm10_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm11_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm12_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm13_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm14_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm15_pmic_temp"
+        ]
+    },
+    {
+        "name": "pmic dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/dimm_pmic_dvfs_temp"
+        ]
+    },
+    {
+        "name": "internal memory buffer temps",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/dimm0_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm1_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm2_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm3_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm4_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm5_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm6_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm7_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm8_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm9_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm10_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm11_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm12_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm13_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm14_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm15_intmb_temp"
+        ]
+    },
+    {
+        "name": "internal memory buffer dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/dimm_intmb_dvfs_temp"
+        ]
+    },
+    {
+        // Repurposed as DRAM temperature sensors for 4U DDIMMs
+        "name": "dram and external memory buffer temps",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/dimm0_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm1_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm2_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm3_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm4_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm5_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm6_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm7_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm8_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm9_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm10_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm11_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm12_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm13_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm14_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm15_dram_extmb_temp"
+        ]
+    },
+    {
+        "name": "dram and external memory buffer dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/dimm_dram_extmb_dvfs_temp"
+        ]
+    },
+    {
+        // Repurposed as PMIC temperature sensors for 4U DDIMMs
+        "name": "external memory buffer temps",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/dimm0_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm1_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm2_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm3_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm4_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm5_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm6_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm7_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm8_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm9_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm10_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm11_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm12_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm13_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm14_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm15_extmb_temp"
+        ]
+    },
+    {
+        "name": "external memory buffer dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/dimm_extmb_dvfs_temp"
+        ]
+    },
+    {
+        "name": "vdd vrm temps",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/vrm_vdd0_temp",
+            "/xyz/openbmc_project/sensors/temperature/vrm_vdd1_temp"
+        ]
+    },
+    {
+        "name": "proc 0 core dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc0_core_dvfs_temp"
+        ]
+    },
+    {
+        "name": "proc 1 core dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc1_core_dvfs_temp"
+        ]
+    },
+    {
+        "name": "proc 0 ioring dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc0_ioring_dvfs_temp"
+        ]
+    },
+    {
+        "name": "proc 1 ioring dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc1_ioring_dvfs_temp"
+        ]
+    },
+    {
+        "name": "nvme temps",
+        "service": "xyz.openbmc_project.NVMeSensor",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/NVMe_1_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_2_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_3_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_4_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_5_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_6_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_7_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_8_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_9_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_10_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_11_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_12_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_13_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_14_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_15_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_16_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_17_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_18_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_19_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_20_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_21_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_22_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_23_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_24_Temp"
+        ]
+    },
+    {
+        "name": "planar temps",
+        "service": "xyz.openbmc_project.HwmonTempSensor",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/PCIE_0_Temp",
+            "/xyz/openbmc_project/sensors/temperature/PCIE_1_Temp"
+        ]
+    },
+    {
+        "name": "flett temps",
+        "service": "xyz.openbmc_project.HwmonTempSensor",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/NVMe_JBOF_Card_C8_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_JBOF_Card_C10_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_JBOF_Card_C11_Temp"
+        ]
+    },
+    {
+        // Bear Lake card
+        "name": "pcie cable card temps",
+        "service": "xyz.openbmc_project.HwmonTempSensor",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/PCIe_Cable_Card_C7_Temp",
+            "/xyz/openbmc_project/sensors/temperature/PCIe_Cable_Card_C9_Temp",
+            "/xyz/openbmc_project/sensors/temperature/PCIe_Cable_Card_C10_Temp",
+            "/xyz/openbmc_project/sensors/temperature/PCIe_Cable_Card_C11_Temp"
+        ]
+    },
+    {
+        "name": "ambient temp",
+        "service": "xyz.openbmc_project.VirtualSensor",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/Ambient_Virtual_Temp"
+        ]
+    },
+    {
+        "name": "altitude",
+        "service": "xyz.openbmc_project.VirtualSensor",
+        "members": ["/xyz/openbmc_project/sensors/altitude/Altitude"]
+    },
+    {
+        "name": "pcie cards",
+        "members": [
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot6/pcie_card6",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot7/pcie_card7",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot8/pcie_card8",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot9/pcie_card9",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10/pcie_card10",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot11/pcie_card11"
+        ]
+    },
+    {
+        "name": "pcie slots",
+        "members": [
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot6",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot7",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot8",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot9",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot11"
+        ]
+    }
+]

--- a/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.BlueRidge1S4U/pcie_cards.json
+++ b/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.BlueRidge1S4U/pcie_cards.json
@@ -223,6 +223,14 @@
             "subsystem_vendor_id": "0x1014",
             "subsystem_id": "0x06C5",
             "floor_index": 2
+        },
+        {
+            "name": "Vanguard 4770 Crypto",
+            "vendor_id": "0x1014",
+            "device_id": "0x06A2",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x06A2",
+            "floor_index": 3
         }
     ]
 }

--- a/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.BlueRidge1S4U/pcie_cards.json
+++ b/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.BlueRidge1S4U/pcie_cards.json
@@ -1,0 +1,228 @@
+{
+    "cards": [
+        {
+            "name": "PHYP had errors getting IDs",
+            "vendor_id": "0xFFFF",
+            "device_id": "0xFFFF",
+            "subsystem_vendor_id": "0xFFFF",
+            "subsystem_id": "0xFFFF",
+            "floor_index": 3
+        },
+        {
+            "name": "Flett",
+            "vendor_id": "0x1014",
+            "device_id": "0x04F2",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x0007",
+            "has_temp_sensor": true
+        },
+        {
+            "name": "Bear Lake and Bear River",
+            "vendor_id": "0x1014",
+            "device_id": "0x04F2",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x0004",
+            "has_temp_sensor": true
+        },
+        {
+            "name": "GTO",
+            "vendor_id": "0x1014",
+            "device_id": "0x034A",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x033B",
+            "floor_index": 2
+        },
+        {
+            "name": "ZR1",
+            "vendor_id": "0x1014",
+            "device_id": "0x034A",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x035E",
+            "floor_index": 2
+        },
+        {
+            "name": "Z06",
+            "vendor_id": "0x1014",
+            "device_id": "0x034A",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x0355",
+            "floor_index": 2
+        },
+        {
+            "name": "Bolt PCIe3 NVMe Flash Adapter II x8 1.6TB",
+            "vendor_id": "0x144D",
+            "device_id": "0xA822",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x0621",
+            "floor_index": 2
+        },
+        {
+            "name": "Bolt PCIe3 NVMe Flash Adapter II x8 3.2TB",
+            "vendor_id": "0x144D",
+            "device_id": "0xA822",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x0622",
+            "floor_index": 2
+        },
+        {
+            "name": "Bolt PCIe3 NVMe Flash Adapter II x8 6.4TB",
+            "vendor_id": "0x144D",
+            "device_id": "0xA822",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x0629",
+            "floor_index": 2
+        },
+        {
+            "name": "Bolt PCIe3 NVMe Flash Adapter III x8 1.6TB",
+            "vendor_id": "0x144D",
+            "device_id": "0xA822",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x064A",
+            "floor_index": 2
+        },
+        {
+            "name": "Bolt PCIe3 NVMe Flash Adapter III x8 3.2TB",
+            "vendor_id": "0x144D",
+            "device_id": "0xA822",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x064B",
+            "floor_index": 2
+        },
+        {
+            "name": "Bolt PCIe3 NVMe Flash Adapter III x8 6.4TB",
+            "vendor_id": "0x144D",
+            "device_id": "0xA822",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x064C",
+            "floor_index": 2
+        },
+        {
+            "name": "Sentry",
+            "vendor_id": "0x1014",
+            "device_id": "0x0466",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x0466",
+            "floor_index": 2
+        },
+        {
+            "name": "Haleakala EN 2Port 100Gb",
+            "vendor_id": "0x15B3",
+            "device_id": "0x1019",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x0635",
+            "floor_index": 1
+        },
+        {
+            "name": "Cedar Lake 100G 2port",
+            "vendor_id": "0x15B3",
+            "device_id": "0x101D",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x06A6",
+            "floor_index": 3
+        },
+        {
+            "name": "Cedar Lake Crypto 100G 2port",
+            "vendor_id": "0x15B3",
+            "device_id": "0x101D",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x06A5",
+            "floor_index": 3
+        },
+        {
+            "name": "Crater Lake 200G 2Port",
+            "vendor_id": "0x15B3",
+            "device_id": "0x101D",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x06A4",
+            "floor_index": 3
+        },
+        {
+            "name": "Crater Lake Crypto 200G 2Port",
+            "vendor_id": "0x15B3",
+            "device_id": "0x101D",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x06A3",
+            "floor_index": 3
+        },
+        {
+            "name": "Kona PCIe4 NVMe U.2 Flash Adapter x8 1.6TB",
+            "vendor_id": "0x144D",
+            "device_id": "0xA824",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x0682",
+            "floor_index": 2
+        },
+        {
+            "name": "Kona PCIe4 NVMe U.2 Flash Adapter x8 3.2TB",
+            "vendor_id": "0x144D",
+            "device_id": "0xA824",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x0683",
+            "floor_index": 2
+        },
+        {
+            "name": "Kona PCIe4 NVMe U.2 Flash Adapter x8 6.4TB",
+            "vendor_id": "0x144D",
+            "device_id": "0xA824",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x0684",
+            "floor_index": 2
+        },
+        {
+            "name": "Castello",
+            "vendor_id": "0x1014",
+            "device_id": "0x0611",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x0611",
+            "floor_index": 3
+        },
+        {
+            "name": "Puntfish",
+            "vendor_id": "0x1077",
+            "device_id": "0x2271",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x069E",
+            "floor_index": 1
+        },
+        {
+            "name": "Bluefish",
+            "vendor_id": "0x10DF",
+            "device_id": "0xE300",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x0614",
+            "floor_index": 1
+        },
+        {
+            "name": "Dragonhead",
+            "vendor_id": "0x1077",
+            "device_id": "0x2089",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x06C6",
+            "floor_index": 3
+        },
+        {
+            "name": "Shale 4 port ROCE adapter",
+            "vendor_id": "0x15B3",
+            "device_id": "0x1021",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x0712",
+            "floor_index": 3
+        },
+        {
+            "name": "2-port 200GbE x16 Gen5 Narwhal",
+            "vendor_id": "0x15B3",
+            "device_id": "0x1021",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x0714",
+            "floor_index": 3
+        },
+        {
+            "name": "Moso PCIe4 64Gb 2-port Fibre Channel Adapter",
+            "vendor_id": "0x1077",
+            "device_id": "0x2289",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x06C5",
+            "floor_index": 2
+        }
+    ]
+}

--- a/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.BlueRidge1S4U/zones.json
+++ b/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.BlueRidge1S4U/zones.json
@@ -1,0 +1,9 @@
+[
+    {
+        "name": "0",
+        "poweron_target": 10400,
+        "default_floor": 10400,
+        "increase_delay": 5,
+        "decrease_interval": 60
+    }
+]

--- a/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.BlueRidge2U/groups.json
+++ b/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.BlueRidge2U/groups.json
@@ -1,0 +1,626 @@
+[
+    {
+        "name": "fan inventory",
+        "members": [
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan0",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan1",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan2",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan3",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan4",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan5"
+        ]
+    },
+    {
+        "name": "fan0 rotor inventory",
+        "members": [
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan0/fan0_0",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan0/fan0_1"
+        ]
+    },
+    {
+        "name": "fan1 rotor inventory",
+        "members": [
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan1/fan1_0",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan1/fan1_1"
+        ]
+    },
+    {
+        "name": "fan2 rotor inventory",
+        "members": [
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan2/fan2_0",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan2/fan2_1"
+        ]
+    },
+    {
+        "name": "fan3 rotor inventory",
+        "members": [
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan3/fan3_0",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan3/fan3_1"
+        ]
+    },
+    {
+        "name": "fan4 rotor inventory",
+        "members": [
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan4/fan4_0",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan4/fan4_1"
+        ]
+    },
+    {
+        "name": "fan5 rotor inventory",
+        "members": [
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan5/fan5_0",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan5/fan5_1"
+        ]
+    },
+    {
+        "name": "occ objects",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/org/open_power/control/occ0",
+            "/org/open_power/control/occ1",
+            "/org/open_power/control/occ2",
+            "/org/open_power/control/occ3"
+        ]
+    },
+    {
+        "name": "proc0 core temps",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc0_core0_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core0_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core1_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core1_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core2_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core2_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core3_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core3_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core4_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core4_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core5_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core5_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core6_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core6_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core7_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core7_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core8_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core8_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core9_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core9_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core10_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core10_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core11_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core11_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core12_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core12_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core13_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core13_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core14_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core14_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core15_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core15_1_temp"
+        ]
+    },
+    {
+        "name": "proc1 core temps",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc1_core0_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core0_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core1_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core1_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core2_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core2_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core3_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core3_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core4_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core4_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core5_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core5_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core6_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core6_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core7_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core7_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core8_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core8_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core9_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core9_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core10_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core10_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core11_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core11_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core12_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core12_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core13_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core13_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core14_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core14_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core15_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core15_1_temp"
+        ]
+    },
+    {
+        "name": "proc2 core temps",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc2_core0_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core0_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core1_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core1_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core2_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core2_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core3_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core3_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core4_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core4_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core5_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core5_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core6_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core6_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core7_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core7_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core8_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core8_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core9_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core9_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core10_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core10_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core11_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core11_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core12_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core12_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core13_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core13_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core14_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core14_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core15_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core15_1_temp"
+        ]
+    },
+    {
+        "name": "proc3 core temps",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc3_core0_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core0_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core1_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core1_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core2_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core2_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core3_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core3_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core4_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core4_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core5_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core5_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core6_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core6_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core7_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core7_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core8_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core8_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core9_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core9_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core10_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core10_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core11_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core11_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core12_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core12_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core13_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core13_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core14_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core14_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core15_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core15_1_temp"
+        ]
+    },
+    {
+        "name": "proc0 ioring temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc0_ioring_temp"
+        ]
+    },
+    {
+        "name": "proc1 ioring temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc1_ioring_temp"
+        ]
+    },
+    {
+        "name": "proc2 ioring temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc2_ioring_temp"
+        ]
+    },
+    {
+        "name": "proc3 ioring temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc3_ioring_temp"
+        ]
+    },
+    {
+        "name": "dram temps",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/dimm0_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm1_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm2_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm3_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm4_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm5_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm6_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm7_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm8_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm9_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm10_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm11_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm12_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm13_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm14_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm15_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm16_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm17_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm18_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm19_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm20_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm21_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm22_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm23_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm24_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm25_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm26_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm27_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm28_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm29_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm30_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm31_dram_temp"
+        ]
+    },
+    {
+        "name": "dram dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/dimm_dram_dvfs_temp"
+        ]
+    },
+    {
+        "name": "pmic temps",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/dimm0_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm1_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm2_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm3_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm4_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm5_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm6_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm7_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm8_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm9_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm10_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm11_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm12_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm13_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm14_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm15_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm16_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm17_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm18_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm19_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm20_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm21_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm22_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm23_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm24_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm25_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm26_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm27_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm28_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm29_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm30_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm31_pmic_temp"
+        ]
+    },
+    {
+        "name": "pmic dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/dimm_pmic_dvfs_temp"
+        ]
+    },
+    {
+        "name": "internal memory buffer temps",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/dimm0_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm1_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm2_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm3_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm4_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm5_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm6_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm7_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm8_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm9_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm10_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm11_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm12_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm13_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm14_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm15_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm16_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm17_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm18_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm19_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm20_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm21_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm22_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm23_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm24_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm25_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm26_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm27_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm28_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm29_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm30_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm31_intmb_temp"
+        ]
+    },
+    {
+        "name": "internal memory buffer dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/dimm_intmb_dvfs_temp"
+        ]
+    },
+    {
+        "name": "dram and external memory buffer temps",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/dimm0_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm1_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm2_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm3_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm4_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm5_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm6_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm7_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm8_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm9_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm10_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm11_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm12_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm13_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm14_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm15_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm16_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm17_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm18_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm19_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm20_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm21_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm22_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm23_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm24_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm25_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm26_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm27_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm28_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm29_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm30_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm31_dram_extmb_temp"
+        ]
+    },
+    {
+        "name": "dram and external memory buffer dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/dimm_dram_extmb_dvfs_temp"
+        ]
+    },
+    {
+        "name": "external memory buffer temps",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/dimm0_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm1_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm2_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm3_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm4_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm5_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm6_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm7_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm8_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm9_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm10_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm11_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm12_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm13_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm14_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm15_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm16_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm17_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm18_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm19_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm20_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm21_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm22_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm23_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm24_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm25_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm26_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm27_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm28_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm29_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm30_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm31_extmb_temp"
+        ]
+    },
+    {
+        "name": "external memory buffer dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/dimm_extmb_dvfs_temp"
+        ]
+    },
+    {
+        "name": "vdd vrm temps",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/vrm_vdd0_temp",
+            "/xyz/openbmc_project/sensors/temperature/vrm_vdd1_temp",
+            "/xyz/openbmc_project/sensors/temperature/vrm_vdd2_temp",
+            "/xyz/openbmc_project/sensors/temperature/vrm_vdd3_temp"
+        ]
+    },
+    {
+        "name": "proc 0 core dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc0_core_dvfs_temp"
+        ]
+    },
+    {
+        "name": "proc 1 core dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc1_core_dvfs_temp"
+        ]
+    },
+    {
+        "name": "proc 2 core dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc2_core_dvfs_temp"
+        ]
+    },
+    {
+        "name": "proc 3 core dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc3_core_dvfs_temp"
+        ]
+    },
+    {
+        "name": "proc 0 ioring dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc0_ioring_dvfs_temp"
+        ]
+    },
+    {
+        "name": "proc 1 ioring dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc1_ioring_dvfs_temp"
+        ]
+    },
+    {
+        "name": "proc 2 ioring dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc2_ioring_dvfs_temp"
+        ]
+    },
+    {
+        "name": "proc 3 ioring dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc3_ioring_dvfs_temp"
+        ]
+    },
+    {
+        "name": "nvme temps",
+        "service": "xyz.openbmc_project.NVMeSensor",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/NVMe_1_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_2_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_3_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_4_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_5_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_6_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_7_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_8_Temp"
+        ]
+    },
+    {
+        "name": "planar temps",
+        "service": "xyz.openbmc_project.HwmonTempSensor",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/PCIE_0_Temp",
+            "/xyz/openbmc_project/sensors/temperature/PCIE_1_Temp"
+        ]
+    },
+    {
+        "name": "flett temps",
+        "service": "xyz.openbmc_project.HwmonTempSensor",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/NVMe_JBOF_Card_C8_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_JBOF_Card_C10_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_JBOF_Card_C11_Temp"
+        ]
+    },
+    {
+        // Bear River card
+        "name": "pcie cable card temps",
+        "service": "xyz.openbmc_project.HwmonTempSensor",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/PCIe_Cable_Card_C0_Temp",
+            "/xyz/openbmc_project/sensors/temperature/PCIe_Cable_Card_C2_Temp",
+            "/xyz/openbmc_project/sensors/temperature/PCIe_Cable_Card_C3_Temp",
+            "/xyz/openbmc_project/sensors/temperature/PCIe_Cable_Card_C4_Temp",
+            "/xyz/openbmc_project/sensors/temperature/PCIe_Cable_Card_C7_Temp",
+            "/xyz/openbmc_project/sensors/temperature/PCIe_Cable_Card_C9_Temp",
+            "/xyz/openbmc_project/sensors/temperature/PCIe_Cable_Card_C10_Temp",
+            "/xyz/openbmc_project/sensors/temperature/PCIe_Cable_Card_C11_Temp"
+        ]
+    },
+    {
+        "name": "ambient temp",
+        "service": "xyz.openbmc_project.VirtualSensor",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/Ambient_Virtual_Temp"
+        ]
+    },
+    {
+        "name": "altitude",
+        "service": "xyz.openbmc_project.VirtualSensor",
+        "members": ["/xyz/openbmc_project/sensors/altitude/Altitude"]
+    },
+    {
+        "name": "pcie cards",
+        "members": [
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot0/pcie_card0",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot1/pcie_card1",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot2/pcie_card2",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot3/pcie_card3",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot4/pcie_card4",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot6/pcie_card6",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot7/pcie_card7",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot8/pcie_card8",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot9/pcie_card9",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10/pcie_card10",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot11/pcie_card11"
+        ]
+    },
+    {
+        "name": "pcie slots",
+        "members": [
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot0",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot1",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot2",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot3",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot4",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot6",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot7",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot8",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot9",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot11"
+        ]
+    }
+]

--- a/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.BlueRidge2U/pcie_cards.json
+++ b/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.BlueRidge2U/pcie_cards.json
@@ -6,7 +6,7 @@
             "device_id": "0xFFFF",
             "subsystem_vendor_id": "0xFFFF",
             "subsystem_id": "0xFFFF",
-            "floor_index": 3
+            "floor_index": 5
         },
         {
             "name": "Flett",
@@ -25,30 +25,6 @@
             "has_temp_sensor": true
         },
         {
-            "name": "GTO",
-            "vendor_id": "0x1014",
-            "device_id": "0x034A",
-            "subsystem_vendor_id": "0x1014",
-            "subsystem_id": "0x033B",
-            "floor_index": 2
-        },
-        {
-            "name": "ZR1",
-            "vendor_id": "0x1014",
-            "device_id": "0x034A",
-            "subsystem_vendor_id": "0x1014",
-            "subsystem_id": "0x035E",
-            "floor_index": 2
-        },
-        {
-            "name": "Z06",
-            "vendor_id": "0x1014",
-            "device_id": "0x034A",
-            "subsystem_vendor_id": "0x1014",
-            "subsystem_id": "0x0355",
-            "floor_index": 2
-        },
-        {
             "name": "Everglades 10Gb 2Port",
             "vendor_id": "0x15B3",
             "device_id": "0x1015",
@@ -65,76 +41,12 @@
             "floor_index": 1
         },
         {
-            "name": "Bolt PCIe3 NVMe Flash Adapter II x8 1.6TB",
-            "vendor_id": "0x144D",
-            "device_id": "0xA822",
-            "subsystem_vendor_id": "0x1014",
-            "subsystem_id": "0x0621",
-            "floor_index": 2
-        },
-        {
-            "name": "Bolt PCIe3 NVMe Flash Adapter II x8 3.2TB",
-            "vendor_id": "0x144D",
-            "device_id": "0xA822",
-            "subsystem_vendor_id": "0x1014",
-            "subsystem_id": "0x0622",
-            "floor_index": 2
-        },
-        {
-            "name": "Bolt PCIe3 NVMe Flash Adapter II x8 6.4TB",
-            "vendor_id": "0x144D",
-            "device_id": "0xA822",
-            "subsystem_vendor_id": "0x1014",
-            "subsystem_id": "0x0629",
-            "floor_index": 2
-        },
-        {
-            "name": "Bolt PCIe3 NVMe Flash Adapter III x8 1.6TB",
-            "vendor_id": "0x144D",
-            "device_id": "0xA822",
-            "subsystem_vendor_id": "0x1014",
-            "subsystem_id": "0x064A",
-            "floor_index": 2
-        },
-        {
-            "name": "Bolt PCIe3 NVMe Flash Adapter III x8 3.2TB",
-            "vendor_id": "0x144D",
-            "device_id": "0xA822",
-            "subsystem_vendor_id": "0x1014",
-            "subsystem_id": "0x064B",
-            "floor_index": 2
-        },
-        {
-            "name": "Bolt PCIe3 NVMe Flash Adapter III x8 6.4TB",
-            "vendor_id": "0x144D",
-            "device_id": "0xA822",
-            "subsystem_vendor_id": "0x1014",
-            "subsystem_id": "0x064C",
-            "floor_index": 2
-        },
-        {
-            "name": "Sentry",
-            "vendor_id": "0x1014",
-            "device_id": "0x0466",
-            "subsystem_vendor_id": "0x1014",
-            "subsystem_id": "0x0466",
-            "floor_index": 2
-        },
-        {
-            "name": "Haleakala EN 2Port 100Gb",
-            "vendor_id": "0x15B3",
-            "device_id": "0x1019",
-            "subsystem_vendor_id": "0x1014",
-            "subsystem_id": "0x0635",
-            "floor_index": 3
-        },
-        {
             "name": "Cedar Lake 100G 2port",
             "vendor_id": "0x15B3",
             "device_id": "0x101D",
             "subsystem_vendor_id": "0x1014",
             "subsystem_id": "0x06A6",
-            "floor_index": 3
+            "floor_index": 5
         },
         {
             "name": "Cedar Lake Crypto 100G 2port",
@@ -142,23 +54,63 @@
             "device_id": "0x101D",
             "subsystem_vendor_id": "0x1014",
             "subsystem_id": "0x06A5",
+            "floor_index": 5
+        },
+        {
+            "name": "GTO",
+            "vendor_id": "0x1014",
+            "device_id": "0x034A",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x033B",
             "floor_index": 3
         },
         {
-            "name": "Crater Lake 200G 2Port",
-            "vendor_id": "0x15B3",
-            "device_id": "0x101D",
+            "name": "Bolt PCIe3 NVMe Flash Adapter II x8 1.6TB",
+            "vendor_id": "0x144D",
+            "device_id": "0xA822",
             "subsystem_vendor_id": "0x1014",
-            "subsystem_id": "0x06A4",
+            "subsystem_id": "0x0621",
             "floor_index": 3
         },
         {
-            "name": "Crater Lake Crypto 200G 2Port",
-            "vendor_id": "0x15B3",
-            "device_id": "0x101D",
+            "name": "Bolt PCIe3 NVMe Flash Adapter II x8 3.2TB",
+            "vendor_id": "0x144D",
+            "device_id": "0xA822",
             "subsystem_vendor_id": "0x1014",
-            "subsystem_id": "0x06A3",
+            "subsystem_id": "0x0622",
+            "floor_index": 4
+        },
+        {
+            "name": "Bolt PCIe3 NVMe Flash Adapter II x8 6.4TB",
+            "vendor_id": "0x144D",
+            "device_id": "0xA822",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x0629",
+            "floor_index": 4
+        },
+        {
+            "name": "Bolt PCIe3 NVMe Flash Adapter III x8 1.6TB",
+            "vendor_id": "0x144D",
+            "device_id": "0xA822",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x064A",
             "floor_index": 3
+        },
+        {
+            "name": "Bolt PCIe3 NVMe Flash Adapter III x8 3.2TB",
+            "vendor_id": "0x144D",
+            "device_id": "0xA822",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x064B",
+            "floor_index": 4
+        },
+        {
+            "name": "Bolt PCIe3 NVMe Flash Adapter III x8 6.4TB",
+            "vendor_id": "0x144D",
+            "device_id": "0xA822",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x064C",
+            "floor_index": 4
         },
         {
             "name": "Kona PCIe4 NVMe U.2 Flash Adapter x8 1.6TB",
@@ -166,7 +118,7 @@
             "device_id": "0xA824",
             "subsystem_vendor_id": "0x1014",
             "subsystem_id": "0x0682",
-            "floor_index": 2
+            "floor_index": 4
         },
         {
             "name": "Kona PCIe4 NVMe U.2 Flash Adapter x8 3.2TB",
@@ -174,7 +126,7 @@
             "device_id": "0xA824",
             "subsystem_vendor_id": "0x1014",
             "subsystem_id": "0x0683",
-            "floor_index": 2
+            "floor_index": 4
         },
         {
             "name": "Kona PCIe4 NVMe U.2 Flash Adapter x8 6.4TB",
@@ -182,15 +134,7 @@
             "device_id": "0xA824",
             "subsystem_vendor_id": "0x1014",
             "subsystem_id": "0x0684",
-            "floor_index": 2
-        },
-        {
-            "name": "Castello",
-            "vendor_id": "0x1014",
-            "device_id": "0x0611",
-            "subsystem_vendor_id": "0x1014",
-            "subsystem_id": "0x0611",
-            "floor_index": 3
+            "floor_index": 4
         },
         {
             "name": "Puntfish",
@@ -201,28 +145,44 @@
             "floor_index": 1
         },
         {
-            "name": "Bluefish",
-            "vendor_id": "0x10DF",
-            "device_id": "0xE300",
+            "name": "Flavafish",
+            "vendor_id": "0x1077",
+            "device_id": "0x2281",
             "subsystem_vendor_id": "0x1014",
-            "subsystem_id": "0x0614",
+            "subsystem_id": "0x0651",
             "floor_index": 1
         },
         {
-            "name": "Dragonhead",
-            "vendor_id": "0x1077",
-            "device_id": "0x2089",
+            "name": "Haleakala EN 2Port 100Gb",
+            "vendor_id": "0x15B3",
+            "device_id": "0x1019",
             "subsystem_vendor_id": "0x1014",
-            "subsystem_id": "0x06C6",
-            "floor_index": 3
+            "subsystem_id": "0x0635",
+            "floor_index": 5
         },
         {
-            "name": "Shale 4 port ROCE adapter",
+            "name": "Crater Lake Crypto 200G 2Port",
             "vendor_id": "0x15B3",
-            "device_id": "0x1021",
+            "device_id": "0x101D",
             "subsystem_vendor_id": "0x1014",
-            "subsystem_id": "0x0712",
-            "floor_index": 3
+            "subsystem_id": "0x06A3",
+            "floor_index": 5
+        },
+        {
+            "name": "Crater Lake 200G 2Port",
+            "vendor_id": "0x15B3",
+            "device_id": "0x101D",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x06A4",
+            "floor_index": 5
+        },
+        {
+            "name": "Lassen 2 Port IB",
+            "vendor_id": "0x15B3",
+            "device_id": "0x1019",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x0617",
+            "floor_index": 5
         },
         {
             "name": "2-port 200GbE x16 Gen5 Narwhal",
@@ -230,7 +190,7 @@
             "device_id": "0x1021",
             "subsystem_vendor_id": "0x1014",
             "subsystem_id": "0x0714",
-            "floor_index": 3
+            "floor_index": 5
         },
         {
             "name": "Moso PCIe4 64Gb 2-port Fibre Channel Adapter",
@@ -238,7 +198,7 @@
             "device_id": "0x2289",
             "subsystem_vendor_id": "0x1014",
             "subsystem_id": "0x06C5",
-            "floor_index": 2
+            "floor_index": 3
         },
         {
             "name": "Vanguard 4770 Crypto",
@@ -246,7 +206,7 @@
             "device_id": "0x06A2",
             "subsystem_vendor_id": "0x1014",
             "subsystem_id": "0x06A2",
-            "floor_index": 3
+            "floor_index": 5
         }
     ]
 }

--- a/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.BlueRidge4U/events.json
+++ b/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.BlueRidge4U/events.json
@@ -1,0 +1,1703 @@
+[
+    {
+        // Hold fans at the given target when a number of fans are missing.
+        "name": "fan(s) missing",
+        "groups": [
+            {
+                "name": "fan inventory",
+                "interface": "xyz.openbmc_project.Inventory.Item",
+                "property": { "name": "Present" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            }
+        ],
+        "actions": [
+            {
+                "name": "count_state_before_target",
+                "count": 1,
+                "state": false,
+                "target": 10400
+            }
+        ]
+    },
+    {
+        // Hold fans at the given target when a number of rotors are nonfunctional.
+        "name": "fan rotor(s) faulted",
+        "groups": [
+            {
+                "name": "fan0 rotor inventory",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "fan1 rotor inventory",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "fan2 rotor inventory",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "fan3 rotor inventory",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "fan4 rotor inventory",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "fan5 rotor inventory",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            }
+        ],
+        "actions": [
+            {
+                "name": "count_state_before_target",
+                "count": 1,
+                "state": false,
+                "target": 10400
+            }
+        ]
+    },
+    {
+        // Hold fans at the given target when any critical service
+        // is not running for 5 seconds.
+        "name": "service(s) missing",
+        "groups": [
+            {
+                "name": "fan inventory",
+                "interface": "xyz.openbmc_project.Inventory.Item",
+                "property": { "name": "Present" }
+            },
+            {
+                "name": "occ objects",
+                "interface": "org.open_power.OCC.Status",
+                "property": { "name": "OccActive" }
+            },
+            {
+                "name": "nvme temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "planar temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "flett temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "pcie cable card temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "ambient temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "signal",
+                "signal": "name_owner_changed"
+            },
+            {
+                "class": "init",
+                "method": "name_has_owner"
+            }
+        ],
+        "actions": [
+            {
+                "name": "call_actions_based_on_timer",
+                "timer": {
+                    "interval": 5000000,
+                    "type": "oneshot"
+                },
+                "actions": [
+                    {
+                        "name": "set_target_on_missing_owner",
+                        "groups": [
+                            {
+                                "name": "fan inventory",
+                                "interface": "xyz.openbmc_project.Inventory.Item",
+                                "property": { "name": "Present" }
+                            },
+                            {
+                                "name": "occ objects",
+                                "interface": "org.open_power.OCC.Status",
+                                "property": { "name": "OccActive" }
+                            },
+                            {
+                                "name": "nvme temps",
+                                "interface": "xyz.openbmc_project.Sensor.Value",
+                                "property": { "name": "Value" }
+                            },
+                            {
+                                "name": "planar temps",
+                                "interface": "xyz.openbmc_project.Sensor.Value",
+                                "property": { "name": "Value" }
+                            },
+                            {
+                                "name": "flett temps",
+                                "interface": "xyz.openbmc_project.Sensor.Value",
+                                "property": { "name": "Value" }
+                            },
+                            {
+                                "name": "pcie cable card temps",
+                                "interface": "xyz.openbmc_project.Sensor.Value",
+                                "property": { "name": "Value" }
+                            },
+                            {
+                                "name": "ambient temp",
+                                "interface": "xyz.openbmc_project.Sensor.Value",
+                                "property": { "name": "Value" }
+                            }
+                        ],
+                        "target": 10400
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Force retry on the OCC status objects",
+        "groups": [
+            {
+                "name": "occ objects",
+                "interface": "org.open_power.OCC.Status",
+                "property": { "name": "OccActive" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "timer",
+                "type": "oneshot",
+                "interval": 30000000,
+                "preload_groups": true
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_target_on_missing_owner",
+                "groups": [
+                    {
+                        "name": "occ objects",
+                        "interface": "org.open_power.OCC.Status",
+                        "property": { "name": "OccActive" }
+                    }
+                ],
+                "target": 10400
+            }
+        ]
+    },
+    {
+        // Set a fan floor if an OCC isn't active
+        "name": "Non-active OCCs",
+        "groups": [
+            {
+                "name": "occ objects",
+                "interface": "org.open_power.OCC.Status",
+                "property": {
+                    "name": "OccActive"
+                }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            },
+            {
+                "class": "init",
+                "method": "get_properties"
+            }
+        ],
+        "actions": [
+            {
+                "name": "count_state_floor",
+                "count": 1,
+                "state": false,
+                "floor": 10400
+            }
+        ]
+    },
+    {
+        // Set a raised fan floor when any temperature sensor is nonfunctional
+        "name": "Nonfunctional temperature sensors",
+        "groups": [
+            {
+                "name": "proc0 core temps",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "proc1 core temps",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "proc2 core temps",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "proc3 core temps",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "proc0 ioring temp",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "proc1 ioring temp",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "proc2 ioring temp",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "proc3 ioring temp",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "dram temps",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "pmic temps",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "internal memory buffer temps",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "dram and external memory buffer temps",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "external memory buffer temps",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "vdd vrm temps",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "nvme temps",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "planar temps",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "flett temps",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "pcie cable card temps",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            },
+            {
+                "name": "ambient temp",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_removed"
+            },
+            {
+                "class": "init",
+                "method": "get_properties"
+            }
+        ],
+        "actions": [
+            {
+                "name": "count_state_floor",
+                "count": 1,
+                "state": false,
+                "delay": 5,
+                "floor": 10400
+            }
+        ]
+    },
+    {
+        "name": "Set Proc 0 Core DVFS parameter",
+        "groups": [
+            {
+                "name": "proc 0 core dvfs temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_0_core_dvfs_increase_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 10
+                }
+            },
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_0_core_dvfs_decrease_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 13
+                }
+            }
+        ]
+    },
+    {
+        "name": "Set Proc 1 Core DVFS parameter",
+        "groups": [
+            {
+                "name": "proc 1 core dvfs temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_1_core_dvfs_increase_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 10
+                }
+            },
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_1_core_dvfs_decrease_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 13
+                }
+            }
+        ]
+    },
+    {
+        "name": "Set Proc 2 Core DVFS parameter",
+        "groups": [
+            {
+                "name": "proc 2 core dvfs temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_2_core_dvfs_increase_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 10
+                }
+            },
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_2_core_dvfs_decrease_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 13
+                }
+            }
+        ]
+    },
+    {
+        "name": "Set Proc 3 Core DVFS parameter",
+        "groups": [
+            {
+                "name": "proc 3 core dvfs temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_3_core_dvfs_increase_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 10
+                }
+            },
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_3_core_dvfs_decrease_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 13
+                }
+            }
+        ]
+    },
+    {
+        "name": "Set Proc 0 IO Ring DVFS parameter",
+        "groups": [
+            {
+                "name": "proc 0 ioring dvfs temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_0_ioring_dvfs_increase_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 10
+                }
+            },
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_0_ioring_dvfs_decrease_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 13
+                }
+            }
+        ]
+    },
+
+    {
+        "name": "Set Proc 1 IO Ring DVFS parameter",
+        "groups": [
+            {
+                "name": "proc 1 ioring dvfs temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_1_ioring_dvfs_increase_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 10
+                }
+            },
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_1_ioring_dvfs_decrease_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 13
+                }
+            }
+        ]
+    },
+    {
+        "name": "Set Proc 2 IO Ring DVFS parameter",
+        "groups": [
+            {
+                "name": "proc 2 ioring dvfs temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_2_ioring_dvfs_increase_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 10
+                }
+            },
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_2_ioring_dvfs_decrease_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 13
+                }
+            }
+        ]
+    },
+    {
+        "name": "Set Proc 3 IO Ring DVFS parameter",
+        "groups": [
+            {
+                "name": "proc 3 ioring dvfs temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_3_ioring_dvfs_increase_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 10
+                }
+            },
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "proc_3_ioring_dvfs_decrease_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 13
+                }
+            }
+        ]
+    },
+    {
+        "name": "Set DRAM DVFS parameter",
+        "groups": [
+            {
+                "name": "dram dvfs temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "dram_dvfs_increase_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 10
+                }
+            },
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "dram_dvfs_decrease_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 13
+                }
+            }
+        ]
+    },
+    {
+        "name": "Set PMIC DVFS parameter",
+        "groups": [
+            {
+                "name": "pmic dvfs temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "pmic_dvfs_increase_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 10
+                }
+            },
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "pmic_dvfs_decrease_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 13
+                }
+            }
+        ]
+    },
+    {
+        "name": "Set internal memory buffer DVFS parameter",
+        "groups": [
+            {
+                "name": "internal memory buffer dvfs temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "intmb_dvfs_increase_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 10
+                }
+            },
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "intmb_dvfs_decrease_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 13
+                }
+            }
+        ]
+    },
+    {
+        "name": "Set DRAM and external memory buffer DVFS parameter",
+        "groups": [
+            {
+                "name": "dram and external memory buffer dvfs temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "dram_extmb_dvfs_increase_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 10
+                }
+            },
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "dram_extmb_dvfs_decrease_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 13
+                }
+            }
+        ]
+    },
+    {
+        "name": "Set external memory buffer DVFS parameter",
+        "groups": [
+            {
+                "name": "external memory buffer dvfs temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "extmb_dvfs_increase_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 7
+                }
+            },
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "extmb_dvfs_decrease_temp",
+                "modifier": {
+                    "operator": "minus",
+                    "value": 10
+                }
+            }
+        ]
+    },
+    {
+        // Collect group temperatures each iteration the repeating timer expires
+        "name": "Fan control timer loop",
+        "groups": [
+            {
+                "name": "proc0 core temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "proc1 core temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "proc2 core temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "proc3 core temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "proc0 ioring temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "proc1 ioring temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "proc2 ioring temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "proc3 ioring temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "dram temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "pmic temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "internal memory buffer temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "dram and external memory buffer temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "external memory buffer temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "vdd vrm temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "nvme temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "planar temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "flett temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "pcie cable card temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "timer",
+                "type": "repeating",
+                "interval": 2000000,
+                "preload_groups": true
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "proc0 core temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_0_core_dvfs_increase_temp",
+                "delta": 300
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "proc1 core temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_1_core_dvfs_increase_temp",
+                "delta": 300
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "proc2 core temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_2_core_dvfs_increase_temp",
+                "delta": 300
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "proc3 core temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_3_core_dvfs_increase_temp",
+                "delta": 300
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "proc0 ioring temp",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_0_ioring_dvfs_increase_temp",
+                "delta": 300
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "proc1 ioring temp",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_1_ioring_dvfs_increase_temp",
+                "delta": 300
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "proc2 ioring temp",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_2_ioring_dvfs_increase_temp",
+                "delta": 300
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "proc3 ioring temp",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_3_ioring_dvfs_increase_temp",
+                "delta": 300
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "dram temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "dram_dvfs_increase_temp",
+                "delta": 200
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "pmic temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "pmic_dvfs_increase_temp",
+                "delta": 200
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "internal memory buffer temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "intmb_dvfs_increase_temp",
+                "delta": 100
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "dram and external memory buffer temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "dram_extmb_dvfs_increase_temp",
+                "delta": 200
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "external memory buffer temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "extmb_dvfs_increase_temp",
+                "delta": 200
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "vdd vrm temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state": 82.0,
+                "delta": 300
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "nvme temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state": 58.0,
+                "delta": 200
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "planar temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state": 65.0,
+                "delta": 255
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "flett temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state": 80.0,
+                "delta": 200
+            },
+            {
+                "name": "set_net_increase_target",
+                "groups": [
+                    {
+                        "name": "pcie cable card temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state": 70.0,
+                "delta": 255
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "proc0 core temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_0_core_dvfs_decrease_temp",
+                "delta": 50
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "proc1 core temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_1_core_dvfs_decrease_temp",
+                "delta": 50
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "proc2 core temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_2_core_dvfs_decrease_temp",
+                "delta": 50
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "proc3 core temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_3_core_dvfs_decrease_temp",
+                "delta": 50
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "proc0 ioring temp",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_0_ioring_dvfs_decrease_temp",
+                "delta": 50
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "proc1 ioring temp",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_1_ioring_dvfs_decrease_temp",
+                "delta": 50
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "proc2 ioring temp",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_2_ioring_dvfs_decrease_temp",
+                "delta": 50
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "proc3 ioring temp",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "proc_3_ioring_dvfs_decrease_temp",
+                "delta": 50
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "dram temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "dram_dvfs_decrease_temp",
+                "delta": 50
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "pmic temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "pmic_dvfs_decrease_temp",
+                "delta": 50
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "internal memory buffer temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "intmb_dvfs_decrease_temp",
+                "delta": 50
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "dram and external memory buffer temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "dram_extmb_dvfs_decrease_temp",
+                "delta": 50
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "external memory buffer temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state_parameter_name": "extmb_dvfs_decrease_temp",
+                "delta": 50
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "vdd vrm temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state": 79.0,
+                "delta": 50
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "nvme temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state": 55.0,
+                "delta": 50
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "planar temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state": 60.0,
+                "delta": 50
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "flett temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state": 75.0,
+                "delta": 40
+            },
+            {
+                "name": "set_net_decrease_target",
+                "groups": [
+                    {
+                        "name": "pcie cable card temps",
+                        "interface": "xyz.openbmc_project.Sensor.Value",
+                        "property": { "name": "Value" }
+                    }
+                ],
+                "state": 65.0,
+                "delta": 50
+            }
+        ]
+    },
+    {
+        // Remove NVMe temperature objects from cache when they are removed from
+        // dbus. There's no need to react to their removal.
+        "name": "remove nvme objects",
+        "groups": [
+            {
+                "name": "nvme temps",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "nvme temps",
+                "interface": "xyz.openbmc_project.State.Decorator.OperationalStatus",
+                "property": { "name": "Functional" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "signal",
+                "signal": "interfaces_removed"
+            }
+        ]
+    },
+    {
+        "name": "set pcie floor index",
+        "groups": [
+            {
+                "name": "pcie slots",
+                "interface": "xyz.openbmc_project.State.Decorator.PowerState",
+                "property": {
+                    "name": "PowerState"
+                }
+            },
+            {
+                "name": "pcie cards",
+                "interface": "xyz.openbmc_project.Inventory.Item.PCIeDevice",
+                "property": {
+                    "name": "Function0DeviceId"
+                }
+            },
+            {
+                "name": "pcie cards",
+                "interface": "xyz.openbmc_project.Inventory.Item.PCIeDevice",
+                "property": {
+                    "name": "Function0VendorId"
+                }
+            },
+            {
+                "name": "pcie cards",
+                "interface": "xyz.openbmc_project.Inventory.Item.PCIeDevice",
+                "property": {
+                    "name": "Function0SubsystemId"
+                }
+            },
+            {
+                "name": "pcie cards",
+                "interface": "xyz.openbmc_project.Inventory.Item.PCIeDevice",
+                "property": {
+                    "name": "Function0SubsystemVendorId"
+                }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            }
+        ],
+        "actions": [
+            {
+                "name": "pcie_card_floors",
+                "use_config_specific_files": true,
+                "settle_time": 2
+            }
+        ]
+    },
+    {
+        "name": "Set altitude offset parameter",
+        "groups": [
+            {
+                "name": "altitude",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            },
+            {
+                // Refresh altitude every 24hrs
+                "class": "timer",
+                "type": "repeating",
+                "interval": 86400000000,
+                "preload_groups": true
+            }
+        ],
+        "actions": [
+            {
+                "name": "set_parameter_from_group_max",
+                "parameter_name": "altitude_offset",
+                "modifier": {
+                    "operator": "less_than",
+                    "default_value": 3000,
+                    "value": [
+                        { "arg_value": 1000, "parameter_value": 0 },
+                        { "arg_value": 1900, "parameter_value": 1000 },
+                        { "arg_value": 2800, "parameter_value": 2000 }
+                    ]
+                }
+            }
+        ]
+    },
+    {
+        "name": "Fan floors",
+        "groups": [
+            {
+                "name": "ambient temp",
+                "interface": "xyz.openbmc_project.Sensor.Value",
+                "property": { "name": "Value" }
+            },
+            {
+                "name": "power mode",
+                "interface": "xyz.openbmc_project.Control.Power.Mode",
+                "property": { "name": "PowerMode" }
+            }
+        ],
+        "triggers": [
+            {
+                "class": "init",
+                "method": "get_properties"
+            },
+            {
+                "class": "signal",
+                "signal": "properties_changed"
+            },
+            {
+                "class": "signal",
+                "signal": "interfaces_added"
+            },
+            {
+                "class": "parameter",
+                "parameter": "pcie_floor_index"
+            },
+            {
+                "class": "parameter",
+                "parameter": "altitude_offset"
+            }
+        ],
+        "actions": [
+            {
+                "name": "mapped_floor",
+                "key_group": "ambient temp",
+                "fan_floors": [
+                    {
+                        // Entry valid for ambient temp < 27
+                        "key": 27,
+                        "default_floor": 5000,
+                        "floor_offset_parameter": "altitude_offset",
+                        "floors": [
+                            {
+                                "parameter": "pcie_floor_index",
+                                "floors": [
+                                    { "value": 1, "floor": 7000 },
+                                    { "value": 2, "floor": 8000 },
+                                    { "value": 3, "floor": 9000 }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        // Entry valid for ambient temp < 32
+                        "key": 32,
+                        "default_floor": 6000,
+                        "floor_offset_parameter": "altitude_offset",
+                        "floors": [
+                            {
+                                "parameter": "pcie_floor_index",
+                                "floors": [
+                                    { "value": 1, "floor": 8000 },
+                                    { "value": 2, "floor": 9000 },
+                                    { "value": 3, "floor": 9500 }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        // Entry valid for ambient temp < 37
+                        "key": 37,
+                        "default_floor": 7000,
+                        "floor_offset_parameter": "altitude_offset",
+                        "floors": [
+                            {
+                                "parameter": "pcie_floor_index",
+                                "floors": [
+                                    { "value": 1, "floor": 9000 },
+                                    { "value": 2, "floor": 9500 },
+                                    { "value": 3, "floor": 10400 }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        // Entry valid for ambient temp < 42
+                        "key": 42,
+                        "default_floor": 8000,
+                        "floor_offset_parameter": "altitude_offset",
+                        "floors": [
+                            {
+                                "parameter": "pcie_floor_index",
+                                "floors": [
+                                    { "value": 1, "floor": 9500 },
+                                    { "value": 2, "floor": 10400 },
+                                    { "value": 3, "floor": 10400 }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+]

--- a/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.BlueRidge4U/groups.json
+++ b/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.BlueRidge4U/groups.json
@@ -1,0 +1,643 @@
+[
+    {
+        "name": "fan inventory",
+        "members": [
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan0",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan1",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan2",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan3",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan4",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan5"
+        ]
+    },
+    {
+        "name": "fan0 rotor inventory",
+        "members": [
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan0/fan0_0"
+        ]
+    },
+    {
+        "name": "fan1 rotor inventory",
+        "members": [
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan1/fan1_0"
+        ]
+    },
+    {
+        "name": "fan2 rotor inventory",
+        "members": [
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan2/fan2_0"
+        ]
+    },
+    {
+        "name": "fan3 rotor inventory",
+        "members": [
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan3/fan3_0"
+        ]
+    },
+    {
+        "name": "fan4 rotor inventory",
+        "members": [
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan4/fan4_0"
+        ]
+    },
+    {
+        "name": "fan5 rotor inventory",
+        "members": [
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/fan5/fan5_0"
+        ]
+    },
+    {
+        "name": "occ objects",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/org/open_power/control/occ0",
+            "/org/open_power/control/occ1",
+            "/org/open_power/control/occ2",
+            "/org/open_power/control/occ3"
+        ]
+    },
+    {
+        "name": "proc0 core temps",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc0_core0_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core0_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core1_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core1_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core2_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core2_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core3_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core3_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core4_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core4_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core5_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core5_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core6_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core6_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core7_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core7_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core8_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core8_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core9_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core9_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core10_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core10_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core11_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core11_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core12_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core12_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core13_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core13_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core14_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core14_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core15_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc0_core15_1_temp"
+        ]
+    },
+    {
+        "name": "proc1 core temps",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc1_core0_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core0_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core1_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core1_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core2_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core2_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core3_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core3_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core4_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core4_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core5_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core5_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core6_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core6_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core7_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core7_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core8_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core8_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core9_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core9_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core10_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core10_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core11_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core11_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core12_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core12_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core13_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core13_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core14_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core14_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core15_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc1_core15_1_temp"
+        ]
+    },
+    {
+        "name": "proc2 core temps",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc2_core0_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core0_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core1_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core1_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core2_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core2_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core3_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core3_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core4_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core4_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core5_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core5_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core6_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core6_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core7_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core7_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core8_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core8_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core9_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core9_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core10_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core10_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core11_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core11_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core12_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core12_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core13_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core13_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core14_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core14_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core15_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc2_core15_1_temp"
+        ]
+    },
+    {
+        "name": "proc3 core temps",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc3_core0_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core0_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core1_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core1_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core2_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core2_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core3_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core3_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core4_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core4_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core5_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core5_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core6_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core6_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core7_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core7_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core8_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core8_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core9_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core9_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core10_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core10_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core11_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core11_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core12_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core12_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core13_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core13_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core14_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core14_1_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core15_0_temp",
+            "/xyz/openbmc_project/sensors/temperature/proc3_core15_1_temp"
+        ]
+    },
+    {
+        "name": "proc0 ioring temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc0_ioring_temp"
+        ]
+    },
+    {
+        "name": "proc1 ioring temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc1_ioring_temp"
+        ]
+    },
+    {
+        "name": "proc2 ioring temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc2_ioring_temp"
+        ]
+    },
+    {
+        "name": "proc3 ioring temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc3_ioring_temp"
+        ]
+    },
+    {
+        "name": "dram temps",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/dimm0_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm1_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm2_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm3_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm4_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm5_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm6_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm7_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm8_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm9_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm10_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm11_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm12_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm13_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm14_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm15_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm16_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm17_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm18_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm19_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm20_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm21_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm22_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm23_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm24_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm25_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm26_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm27_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm28_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm29_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm30_dram_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm31_dram_temp"
+        ]
+    },
+    {
+        "name": "dram dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/dimm_dram_dvfs_temp"
+        ]
+    },
+    {
+        "name": "pmic temps",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/dimm0_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm1_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm2_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm3_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm4_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm5_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm6_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm7_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm8_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm9_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm10_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm11_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm12_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm13_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm14_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm15_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm16_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm17_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm18_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm19_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm20_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm21_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm22_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm23_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm24_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm25_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm26_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm27_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm28_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm29_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm30_pmic_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm31_pmic_temp"
+        ]
+    },
+    {
+        "name": "pmic dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/dimm_pmic_dvfs_temp"
+        ]
+    },
+    {
+        "name": "internal memory buffer temps",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/dimm0_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm1_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm2_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm3_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm4_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm5_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm6_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm7_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm8_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm9_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm10_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm11_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm12_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm13_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm14_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm15_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm16_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm17_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm18_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm19_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm20_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm21_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm22_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm23_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm24_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm25_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm26_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm27_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm28_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm29_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm30_intmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm31_intmb_temp"
+        ]
+    },
+    {
+        "name": "internal memory buffer dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/dimm_intmb_dvfs_temp"
+        ]
+    },
+    {
+        // Repurposed as DRAM temperature sensors for 4U DDIMMs
+        "name": "dram and external memory buffer temps",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/dimm0_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm1_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm2_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm3_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm4_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm5_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm6_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm7_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm8_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm9_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm10_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm11_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm12_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm13_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm14_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm15_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm16_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm17_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm18_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm19_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm20_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm21_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm22_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm23_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm24_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm25_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm26_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm27_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm28_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm29_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm30_dram_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm31_dram_extmb_temp"
+        ]
+    },
+    {
+        "name": "dram and external memory buffer dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/dimm_dram_extmb_dvfs_temp"
+        ]
+    },
+    {
+        // Repurposed as PMIC temperature sensors for 4U DDIMMs
+        "name": "external memory buffer temps",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/dimm0_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm1_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm2_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm3_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm4_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm5_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm6_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm7_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm8_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm9_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm10_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm11_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm12_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm13_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm14_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm15_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm16_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm17_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm18_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm19_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm20_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm21_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm22_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm23_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm24_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm25_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm26_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm27_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm28_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm29_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm30_extmb_temp",
+            "/xyz/openbmc_project/sensors/temperature/dimm31_extmb_temp"
+        ]
+    },
+    {
+        "name": "external memory buffer dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/dimm_extmb_dvfs_temp"
+        ]
+    },
+    {
+        "name": "vdd vrm temps",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/vrm_vdd0_temp",
+            "/xyz/openbmc_project/sensors/temperature/vrm_vdd1_temp",
+            "/xyz/openbmc_project/sensors/temperature/vrm_vdd2_temp",
+            "/xyz/openbmc_project/sensors/temperature/vrm_vdd3_temp"
+        ]
+    },
+    {
+        "name": "proc 0 core dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc0_core_dvfs_temp"
+        ]
+    },
+    {
+        "name": "proc 1 core dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc1_core_dvfs_temp"
+        ]
+    },
+    {
+        "name": "proc 2 core dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc2_core_dvfs_temp"
+        ]
+    },
+    {
+        "name": "proc 3 core dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc3_core_dvfs_temp"
+        ]
+    },
+    {
+        "name": "proc 0 ioring dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc0_ioring_dvfs_temp"
+        ]
+    },
+    {
+        "name": "proc 1 ioring dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc1_ioring_dvfs_temp"
+        ]
+    },
+    {
+        "name": "proc 2 ioring dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc2_ioring_dvfs_temp"
+        ]
+    },
+    {
+        "name": "proc 3 ioring dvfs temp",
+        "service": "org.open_power.OCC.Control",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/proc3_ioring_dvfs_temp"
+        ]
+    },
+    {
+        "name": "nvme temps",
+        "service": "xyz.openbmc_project.NVMeSensor",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/NVMe_1_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_2_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_3_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_4_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_5_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_6_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_7_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_8_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_9_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_10_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_11_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_12_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_13_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_14_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_15_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_16_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_17_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_18_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_19_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_20_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_21_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_22_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_23_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_24_Temp"
+        ]
+    },
+    {
+        "name": "planar temps",
+        "service": "xyz.openbmc_project.HwmonTempSensor",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/PCIE_0_Temp",
+            "/xyz/openbmc_project/sensors/temperature/PCIE_1_Temp"
+        ]
+    },
+    {
+        "name": "flett temps",
+        "service": "xyz.openbmc_project.HwmonTempSensor",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/NVMe_JBOF_Card_C8_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_JBOF_Card_C10_Temp",
+            "/xyz/openbmc_project/sensors/temperature/NVMe_JBOF_Card_C11_Temp"
+        ]
+    },
+    {
+        // Bear Lake card
+        "name": "pcie cable card temps",
+        "service": "xyz.openbmc_project.HwmonTempSensor",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/PCIe_Cable_Card_C0_Temp",
+            "/xyz/openbmc_project/sensors/temperature/PCIe_Cable_Card_C2_Temp",
+            "/xyz/openbmc_project/sensors/temperature/PCIe_Cable_Card_C3_Temp",
+            "/xyz/openbmc_project/sensors/temperature/PCIe_Cable_Card_C4_Temp",
+            "/xyz/openbmc_project/sensors/temperature/PCIe_Cable_Card_C7_Temp",
+            "/xyz/openbmc_project/sensors/temperature/PCIe_Cable_Card_C9_Temp",
+            "/xyz/openbmc_project/sensors/temperature/PCIe_Cable_Card_C10_Temp",
+            "/xyz/openbmc_project/sensors/temperature/PCIe_Cable_Card_C11_Temp"
+        ]
+    },
+    {
+        "name": "ambient temp",
+        "service": "xyz.openbmc_project.VirtualSensor",
+        "members": [
+            "/xyz/openbmc_project/sensors/temperature/Ambient_Virtual_Temp"
+        ]
+    },
+    {
+        "name": "altitude",
+        "service": "xyz.openbmc_project.VirtualSensor",
+        "members": ["/xyz/openbmc_project/sensors/altitude/Altitude"]
+    },
+    {
+        "name": "pcie cards",
+        "members": [
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot0/pcie_card0",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot1/pcie_card1",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot2/pcie_card2",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot3/pcie_card3",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot4/pcie_card4",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot6/pcie_card6",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot7/pcie_card7",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot8/pcie_card8",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot9/pcie_card9",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10/pcie_card10",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot11/pcie_card11"
+        ]
+    },
+    {
+        "name": "pcie slots",
+        "members": [
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot0",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot1",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot2",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot3",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot4",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot6",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot7",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot8",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot9",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10",
+            "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot11"
+        ]
+    },
+    {
+        "name": "power mode",
+        "service": "org.open_power.OCC.Control",
+        "members": ["/xyz/openbmc_project/control/host0/power_mode"]
+    }
+]

--- a/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.BlueRidge4U/pcie_cards.json
+++ b/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.BlueRidge4U/pcie_cards.json
@@ -1,0 +1,244 @@
+{
+    "cards": [
+        {
+            "name": "PHYP had errors getting IDs",
+            "vendor_id": "0xFFFF",
+            "device_id": "0xFFFF",
+            "subsystem_vendor_id": "0xFFFF",
+            "subsystem_id": "0xFFFF",
+            "floor_index": 3
+        },
+        {
+            "name": "Flett",
+            "vendor_id": "0x1014",
+            "device_id": "0x04F2",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x0007",
+            "has_temp_sensor": true
+        },
+        {
+            "name": "Bear Lake and Bear River",
+            "vendor_id": "0x1014",
+            "device_id": "0x04F2",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x0004",
+            "has_temp_sensor": true
+        },
+        {
+            "name": "GTO",
+            "vendor_id": "0x1014",
+            "device_id": "0x034A",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x033B",
+            "floor_index": 2
+        },
+        {
+            "name": "ZR1",
+            "vendor_id": "0x1014",
+            "device_id": "0x034A",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x035E",
+            "floor_index": 2
+        },
+        {
+            "name": "Z06",
+            "vendor_id": "0x1014",
+            "device_id": "0x034A",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x0355",
+            "floor_index": 2
+        },
+        {
+            "name": "Everglades 10Gb 2Port",
+            "vendor_id": "0x15B3",
+            "device_id": "0x1015",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x061F",
+            "floor_index": 1
+        },
+        {
+            "name": "Everglades 25Gb 2Port",
+            "vendor_id": "0x15B3",
+            "device_id": "0x1015",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x061E",
+            "floor_index": 1
+        },
+        {
+            "name": "Bolt PCIe3 NVMe Flash Adapter II x8 1.6TB",
+            "vendor_id": "0x144D",
+            "device_id": "0xA822",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x0621",
+            "floor_index": 2
+        },
+        {
+            "name": "Bolt PCIe3 NVMe Flash Adapter II x8 3.2TB",
+            "vendor_id": "0x144D",
+            "device_id": "0xA822",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x0622",
+            "floor_index": 2
+        },
+        {
+            "name": "Bolt PCIe3 NVMe Flash Adapter II x8 6.4TB",
+            "vendor_id": "0x144D",
+            "device_id": "0xA822",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x0629",
+            "floor_index": 2
+        },
+        {
+            "name": "Bolt PCIe3 NVMe Flash Adapter III x8 1.6TB",
+            "vendor_id": "0x144D",
+            "device_id": "0xA822",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x064A",
+            "floor_index": 2
+        },
+        {
+            "name": "Bolt PCIe3 NVMe Flash Adapter III x8 3.2TB",
+            "vendor_id": "0x144D",
+            "device_id": "0xA822",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x064B",
+            "floor_index": 2
+        },
+        {
+            "name": "Bolt PCIe3 NVMe Flash Adapter III x8 6.4TB",
+            "vendor_id": "0x144D",
+            "device_id": "0xA822",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x064C",
+            "floor_index": 2
+        },
+        {
+            "name": "Sentry",
+            "vendor_id": "0x1014",
+            "device_id": "0x0466",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x0466",
+            "floor_index": 2
+        },
+        {
+            "name": "Haleakala EN 2Port 100Gb",
+            "vendor_id": "0x15B3",
+            "device_id": "0x1019",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x0635",
+            "floor_index": 3
+        },
+        {
+            "name": "Cedar Lake 100G 2port",
+            "vendor_id": "0x15B3",
+            "device_id": "0x101D",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x06A6",
+            "floor_index": 3
+        },
+        {
+            "name": "Cedar Lake Crypto 100G 2port",
+            "vendor_id": "0x15B3",
+            "device_id": "0x101D",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x06A5",
+            "floor_index": 3
+        },
+        {
+            "name": "Crater Lake 200G 2Port",
+            "vendor_id": "0x15B3",
+            "device_id": "0x101D",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x06A4",
+            "floor_index": 3
+        },
+        {
+            "name": "Crater Lake Crypto 200G 2Port",
+            "vendor_id": "0x15B3",
+            "device_id": "0x101D",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x06A3",
+            "floor_index": 3
+        },
+        {
+            "name": "Kona PCIe4 NVMe U.2 Flash Adapter x8 1.6TB",
+            "vendor_id": "0x144D",
+            "device_id": "0xA824",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x0682",
+            "floor_index": 2
+        },
+        {
+            "name": "Kona PCIe4 NVMe U.2 Flash Adapter x8 3.2TB",
+            "vendor_id": "0x144D",
+            "device_id": "0xA824",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x0683",
+            "floor_index": 2
+        },
+        {
+            "name": "Kona PCIe4 NVMe U.2 Flash Adapter x8 6.4TB",
+            "vendor_id": "0x144D",
+            "device_id": "0xA824",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x0684",
+            "floor_index": 2
+        },
+        {
+            "name": "Castello",
+            "vendor_id": "0x1014",
+            "device_id": "0x0611",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x0611",
+            "floor_index": 3
+        },
+        {
+            "name": "Puntfish",
+            "vendor_id": "0x1077",
+            "device_id": "0x2271",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x069E",
+            "floor_index": 1
+        },
+        {
+            "name": "Bluefish",
+            "vendor_id": "0x10DF",
+            "device_id": "0xE300",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x0614",
+            "floor_index": 1
+        },
+        {
+            "name": "Dragonhead",
+            "vendor_id": "0x1077",
+            "device_id": "0x2089",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x06C6",
+            "floor_index": 3
+        },
+        {
+            "name": "Shale 4 port ROCE adapter",
+            "vendor_id": "0x15B3",
+            "device_id": "0x1021",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x0712",
+            "floor_index": 3
+        },
+        {
+            "name": "2-port 200GbE x16 Gen5 Narwhal",
+            "vendor_id": "0x15B3",
+            "device_id": "0x1021",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x0714",
+            "floor_index": 3
+        },
+        {
+            "name": "Moso PCIe4 64Gb 2-port Fibre Channel Adapter",
+            "vendor_id": "0x1077",
+            "device_id": "0x2289",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x06C5",
+            "floor_index": 2
+        }
+    ]
+}

--- a/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.BlueRidge4U/zones.json
+++ b/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.BlueRidge4U/zones.json
@@ -1,0 +1,9 @@
+[
+    {
+        "name": "0",
+        "poweron_target": 10400,
+        "default_floor": 10400,
+        "increase_delay": 5,
+        "decrease_interval": 60
+    }
+]

--- a/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.Fuji/pcie_cards.json
+++ b/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.Fuji/pcie_cards.json
@@ -191,6 +191,14 @@
             "subsystem_vendor_id": "0x1014",
             "subsystem_id": "0x06C2",
             "floor_index": 2
+        },
+        {
+            "name": "Vanguard 4770 Crypto",
+            "vendor_id": "0x1014",
+            "device_id": "0x06A2",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x06A2",
+            "floor_index": 3
         }
     ]
 }

--- a/docs/control/events.md
+++ b/docs/control/events.md
@@ -292,7 +292,6 @@ parameter value.
 The above config uses a hardcoded state value:
 
 - For each member of the 'pcie temps' group:
-
   - Read its 'Value' D-Bus property.
   - If that property value is greater than the 'state' value of 70.0:
   - Subtracts 70.0 from the property value.
@@ -318,7 +317,6 @@ The above config uses a hardcoded state value:
 The above config uses a parameter as the state value:
 
 - For each member of the 'proc 0 core temps' group:
-
   - Read its 'Value' D-Bus property.
   - If that property value is greater than the value of the parameter listed in
     the 'state_parameter_name' field, in this case
@@ -357,7 +355,6 @@ parameter value.
 The above config uses a hardcoded state value:
 
 - For each member of the 'pcie temps' group:
-
   - Read its 'Value' D-Bus property.
   - If that property value is less than the 'state' value of 65.0:
   - Subtracts the property value from 65.0.
@@ -383,7 +380,6 @@ The above config uses a hardcoded state value:
 The above config uses a parameter as the state value:
 
 - For each member of the 'proc 0 core temps' group:
-
   - Read its 'Value' D-Bus property.
   - If that property value is less than the value of the parameter listed the
     'state_parameter_name' field, in this case 'proc_0_core_dvfs_decrease_temp':


### PR DESCRIPTION
Applies automatic code formatting to markdown documentation, moves BlueRidge configs into separate directories, and adds config for Vanguard PCIe hot adapter. This needs to be applied to 1110 and 1120.