### PR TITLE
1060: control: Add a retry for FanSpeed iface service (#75)

### DIFF
--- a/control/json/fan.cpp
+++ b/control/json/fan.cpp
@@ -18,6 +18,7 @@
 #include "sdbusplus.hpp"
 
 #include <nlohmann/json.hpp>
+#include <phosphor-logging/lg2.hpp>
 #include <phosphor-logging/log.hpp>
 #include <sdbusplus/bus.hpp>
 
@@ -75,7 +76,30 @@ void Fan::setSensors(const json& jsonObj)
                    sensor.get<std::string>();
         }
 
-        auto service = util::SDBusPlus::getService(_bus, path, _interface);
+        std::string service;
+        int attempts = 0;
+        constexpr int maxAttempts = 5;
+        while (true)
+        {
+            try
+            {
+                service = util::SDBusPlus::getService(_bus, path, _interface);
+                break;
+            }
+            catch (const std::exception&)
+            {
+                lg2::warning("No service for {PATH} {INTERFACE}", "PATH", path,
+                             "INTERFACE", _interface);
+                attempts++;
+                if (attempts == maxAttempts)
+                {
+                    lg2::error("Giving up");
+                    throw;
+                }
+                lg2::info("Retrying");
+                std::this_thread::sleep_for(std::chrono::seconds(2));
+            }
+        }
         _sensors[path] = service;
     }
     // All sensors associated with this fan are set to the same target,


### PR DESCRIPTION
#### control: Add a retry for FanSpeed iface service (#75)
```
On startup, code tries to find the D-bus service that provides the
interface to set the fan speed.  If that service isn't there yet, add in
some retries instead of just throwing an exception and crashing.

In the failing case, phosphor-hwmon-readd is providing that interface.
It's started from a udev event and also has a service name that changes
based on the I2C address of the device, so it isn't really feasible to
hardcode that service as a dependency in the fan control service file.

Tested:

Can see retries:
```
phosphor-fan-control[807]: Loading configuration from /usr/share/phosphor-fan-presence/control/com.ibm.Hardware.Chassis.Model.Everest/fans.json
phosphor-fan-control[807]: No service for /xyz/openbmc_project/sensors/fan_tach/fan0_0 xyz.openbmc_project.Control.FanSpeed
phosphor-fan-control[807]: Retrying
phosphor-fan-monitor[874]: Loading configuration from /usr/share/phosphor-fan-presence/monitor/com.ibm.Hardware.Chassis.Model.Everest/config.json
phosphor-fan-control[807]: Configuration(fans.json) loaded successfully
```

If it never works, service will restart once, and then go to failed
state as desired:
```
phosphor-fan-control[2850]: Giving up
phosphor-fan-control[2850]: Uncaught DBus service lookup failure exception, Path=/xyz/openbmc_project/sensors/fan_tach/fan0_0, Interface=xyz.openbmc_project.Control.FanSpeed
phosphor-fan-control@0.service: Main process exited, code=exited, status=1/FAILURE
phosphor-fan-control@0.service: Failed with result 'exit-code'.
phosphor-fan-control@0.service: Triggering OnFailure= dependencies.
systemd[1]: Starting Fan Watchdog Failure Monitor...
systemd[1]: phosphor-fan-control@0.service: Scheduled restart job, restart counter is at 2.
systemd[1]: phosphor-fan-control@0.service: Start request repeated too quickly.
systemd[1]: phosphor-fan-control@0.service: Failed with result 'exit-code'.
systemd[1]: Failed to start Phosphor Fan Control Daemon.
```


Change-Id: I87299fd895d2f1398712177457c746c842baf3ad

Signed-off-by: Matt Spinler <spinler@us.ibm.com>```