### PR TITLE
configs:ibm: Update Adapters for Rainier/BlueRidge

### DIFF
--- a/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.BlueRidge2U/pcie_cards.json
+++ b/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.BlueRidge2U/pcie_cards.json
@@ -207,6 +207,22 @@
             "subsystem_vendor_id": "0x1014",
             "subsystem_id": "0x06A2",
             "floor_index": 5
+        },
+        {
+            "name": "Manatee 2-PORT 25Gb EN adapter",
+            "vendor_id": "0x15B3",
+            "device_id": "0x101F",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x06AA",
+            "floor_index": 1
+        },
+        {
+            "name": "Manatee Crypto 2-PORT 25Gb EN adapter",
+            "vendor_id": "0x15B3",
+            "device_id": "0x101F",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x06AB",
+            "floor_index": 1
         }
     ]
 }

--- a/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.BlueRidge4U/pcie_cards.json
+++ b/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.BlueRidge4U/pcie_cards.json
@@ -247,6 +247,22 @@
             "subsystem_vendor_id": "0x1014",
             "subsystem_id": "0x06A2",
             "floor_index": 3
+        },
+        {
+            "name": "Manatee 2-PORT 25Gb EN adapter",
+            "vendor_id": "0x15B3",
+            "device_id": "0x101F",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x06AA",
+            "floor_index": 1
+        },
+        {
+            "name": "Manatee Crypto 2-PORT 25Gb EN adapter",
+            "vendor_id": "0x15B3",
+            "device_id": "0x101F",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x06AB",
+            "floor_index": 1
         }
     ]
 }

--- a/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.Rainier1S4U/pcie_cards.json
+++ b/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.Rainier1S4U/pcie_cards.json
@@ -223,6 +223,22 @@
             "subsystem_vendor_id": "0x1014",
             "subsystem_id": "0x06C5",
             "floor_index": 2
+        },
+        {
+            "name": "Manatee 2-PORT 25Gb EN adapter",
+            "vendor_id": "0x15B3",
+            "device_id": "0x101F",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x06AA",
+            "floor_index": 1
+        },
+        {
+            "name": "Manatee Crypto 2-PORT 25Gb EN adapter",
+            "vendor_id": "0x15B3",
+            "device_id": "0x101F",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x06AB",
+            "floor_index": 1
         }
     ]
 }

--- a/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.Rainier2U/pcie_cards.json
+++ b/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.Rainier2U/pcie_cards.json
@@ -199,6 +199,22 @@
             "subsystem_vendor_id": "0x1014",
             "subsystem_id": "0x06C5",
             "floor_index": 3
+        },
+        {
+            "name": "Manatee 2-PORT 25Gb EN adapter",
+            "vendor_id": "0x15B3",
+            "device_id": "0x101F",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x06AA",
+            "floor_index": 1
+        },
+        {
+            "name": "Manatee Crypto 2-PORT 25Gb EN adapter",
+            "vendor_id": "0x15B3",
+            "device_id": "0x101F",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x06AB",
+            "floor_index": 1
         }
     ]
 }

--- a/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.Rainier4U/pcie_cards.json
+++ b/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.Rainier4U/pcie_cards.json
@@ -239,6 +239,22 @@
             "subsystem_vendor_id": "0x1014",
             "subsystem_id": "0x06C5",
             "floor_index": 2
+        },
+        {
+            "name": "Manatee 2-PORT 25Gb EN adapter",
+            "vendor_id": "0x15B3",
+            "device_id": "0x101F",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x06AA",
+            "floor_index": 1
+        },
+        {
+            "name": "Manatee Crypto 2-PORT 25Gb EN adapter",
+            "vendor_id": "0x15B3",
+            "device_id": "0x101F",
+            "subsystem_vendor_id": "0x1014",
+            "subsystem_id": "0x06AB",
+            "floor_index": 1
         }
     ]
 }


### PR DESCRIPTION
Update the PCIe hot cards list for Rainier 2U, 1S4U, and 2S4U, as well as BlueRidge 2U and 4U to include the Manatee and Manatee Crypto adapters, which require extra cooling for these systems.

Tested:
* Verified on a Rainier 2S2U that the system successfully loaded Manatee Crypto adapter and set the correct floor index.

Change-Id: I7568b4f0fa8549ad3acea29efc324393a07761b4