### PR TITLE
configs:ibm: Decrease Internal Memory DVFS Delta

### DIFF
--- a/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.Balcones/events.json
+++ b/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.Balcones/events.json
@@ -513,7 +513,7 @@
                 "parameter_name": "intmb_dvfs_increase_temp",
                 "modifier": {
                     "operator": "minus",
-                    "value": 14
+                    "value": 13
                 }
             },
             {
@@ -521,7 +521,7 @@
                 "parameter_name": "intmb_dvfs_decrease_temp",
                 "modifier": {
                     "operator": "minus",
-                    "value": 17
+                    "value": 16
                 }
             }
         ]


### PR DESCRIPTION
Decrease the internal memory DVFS deltas for the Odyssey card on Balcones by one. This is to help acoustics reach targets for Balcones Tower systems.

Change-Id: I9821057a5c87a17e1aeba3391a7b3812a73cd03d