### PR TITLE
control: Increase Fan Speed Interface Retries

### DIFF
--- a/control/json/fan.cpp
+++ b/control/json/fan.cpp
@@ -75,7 +75,7 @@ void Fan::setSensors(const json& jsonObj)
 
         std::string service;
         int attempts = 0;
-        constexpr int maxAttempts = 5;
+        constexpr int maxAttempts = 15;
         while (true)
         {
             try


### PR DESCRIPTION
Increase the max retries for finding the fan speed interface on DBus from 5 to 15. This is to avoid a race condition between the interface being posted and the fan control application starting up.

Tested:
* Power-cycled the chassis in simulation and verified that no dumps were generated.

Change-Id: I47571e3ce4550f14de32169721b44d21482d8502