### PR TITLE
1120: configs:ibm: Update PCIe Fan Floors for Fuji (#86)

### DIFF
--- a/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.Fuji/events.json
+++ b/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.Fuji/events.json
@@ -2402,9 +2402,9 @@
                             {
                                 "parameter": "pcie_floor_index",
                                 "floors": [
-                                    { "value": 1, "floor": 3800 },
-                                    { "value": 2, "floor": 4200 },
-                                    { "value": 3, "floor": 4600 },
+                                    { "value": 1, "floor": 4100 },
+                                    { "value": 2, "floor": 4700 },
+                                    { "value": 3, "floor": 5200 },
                                     { "value": 4, "floor": 6500 }
                                 ]
                             }
@@ -2419,9 +2419,9 @@
                             {
                                 "parameter": "pcie_floor_index",
                                 "floors": [
-                                    { "value": 1, "floor": 4400 },
-                                    { "value": 2, "floor": 4800 },
-                                    { "value": 3, "floor": 5400 },
+                                    { "value": 1, "floor": 4700 },
+                                    { "value": 2, "floor": 5500 },
+                                    { "value": 3, "floor": 6200 },
                                     { "value": 4, "floor": 7500 }
                                 ]
                             }
@@ -2436,9 +2436,9 @@
                             {
                                 "parameter": "pcie_floor_index",
                                 "floors": [
-                                    { "value": 1, "floor": 5000 },
-                                    { "value": 2, "floor": 5600 },
-                                    { "value": 3, "floor": 6500 },
+                                    { "value": 1, "floor": 5300 },
+                                    { "value": 2, "floor": 6400 },
+                                    { "value": 3, "floor": 7400 },
                                     { "value": 4, "floor": 9000 }
                                 ]
                             }
@@ -2453,9 +2453,9 @@
                             {
                                 "parameter": "pcie_floor_index",
                                 "floors": [
-                                    { "value": 1, "floor": 5800 },
-                                    { "value": 2, "floor": 6700 },
-                                    { "value": 3, "floor": 7700 },
+                                    { "value": 1, "floor": 6100 },
+                                    { "value": 2, "floor": 7400 },
+                                    { "value": 3, "floor": 8600 },
                                     { "value": 4, "floor": 11300 }
                                 ]
                             }
@@ -2470,9 +2470,9 @@
                             {
                                 "parameter": "pcie_floor_index",
                                 "floors": [
-                                    { "value": 1, "floor": 6900 },
-                                    { "value": 2, "floor": 7900 },
-                                    { "value": 3, "floor": 9200 },
+                                    { "value": 1, "floor": 7200 },
+                                    { "value": 2, "floor": 8400 },
+                                    { "value": 3, "floor": 9600 },
                                     { "value": 4, "floor": 11300 }
                                 ]
                             }


### PR DESCRIPTION
#### configs:ibm: Update PCIe Fan Floors for Fuji (#86)
```
Update the PCIe floor index definitions for the Fuji events.json config
for fan control. This is to fix adapter instability issues seen with the
system.

Tested:
* Tested on Everest system. Verified events.json config loaded from
  override directory without error.

Change-Id: I74b4fd5a5de32401a582d23494d8449524af7361

Signed-off-by: Anwaar Hadi <anwaar.hadi@ibm.com>```