### PR TITLE
configs:ibm: Add Fractal/Onion Creek to Hot Cards

### DIFF
--- a/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.BlueRidge1S4U/pcie_cards.json
+++ b/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.BlueRidge1S4U/pcie_cards.json
@@ -231,6 +231,22 @@
             "subsystem_vendor_id": "0x1014",
             "subsystem_id": "0x06A2",
             "floor_index": 3
+        },
+        {
+            "name": "Fractal (4-Port 25Gb/10Gb)",
+            "vendor_id": "0x15B3",
+            "device_id": "0x1021",
+            "subsystem_vendor_id": "0x15B3",
+            "subsystem_id": "0x0030",
+            "floor_index": 3
+        },
+        {
+            "name": "Onion Creek (2-PORT 200GbE)",
+            "vendor_id": "0x15B3",
+            "device_id": "0x1021",
+            "subsystem_vendor_id": "0x15B3",
+            "subsystem_id": "0x0022",
+            "floor_index": 3
         }
     ]
 }

--- a/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.BlueRidge2U/pcie_cards.json
+++ b/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.BlueRidge2U/pcie_cards.json
@@ -223,6 +223,14 @@
             "subsystem_vendor_id": "0x1014",
             "subsystem_id": "0x06AB",
             "floor_index": 1
+        },
+        {
+            "name": "Onion Creek (2-PORT 200GbE)",
+            "vendor_id": "0x15B3",
+            "device_id": "0x1021",
+            "subsystem_vendor_id": "0x15B3",
+            "subsystem_id": "0x0022",
+            "floor_index": 5
         }
     ]
 }

--- a/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.BlueRidge4U/pcie_cards.json
+++ b/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.BlueRidge4U/pcie_cards.json
@@ -263,6 +263,22 @@
             "subsystem_vendor_id": "0x1014",
             "subsystem_id": "0x06AB",
             "floor_index": 1
+        },
+        {
+            "name": "Fractal (4-Port 25Gb/10Gb)",
+            "vendor_id": "0x15B3",
+            "device_id": "0x1021",
+            "subsystem_vendor_id": "0x15B3",
+            "subsystem_id": "0x0030",
+            "floor_index": 3
+        },
+        {
+            "name": "Onion Creek (2-PORT 200GbE)",
+            "vendor_id": "0x15B3",
+            "device_id": "0x1021",
+            "subsystem_vendor_id": "0x15B3",
+            "subsystem_id": "0x0022",
+            "floor_index": 3
         }
     ]
 }

--- a/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.Fuji/pcie_cards.json
+++ b/control/config_files/p10bmc/com.ibm.Hardware.Chassis.Model.Fuji/pcie_cards.json
@@ -207,6 +207,22 @@
             "subsystem_vendor_id": "0x1014",
             "subsystem_id": "0x06AA",
             "floor_index": 2
+        },
+        {
+            "name": "Fractal (4-Port 25Gb/10Gb)",
+            "vendor_id": "0x15B3",
+            "device_id": "0x1021",
+            "subsystem_vendor_id": "0x15B3",
+            "subsystem_id": "0x0030",
+            "floor_index": 2
+        },
+        {
+            "name": "Onion Creek (2-PORT 200GbE)",
+            "vendor_id": "0x15B3",
+            "device_id": "0x1021",
+            "subsystem_vendor_id": "0x15B3",
+            "subsystem_id": "0x0022",
+            "floor_index": 4
         }
     ]
 }


### PR DESCRIPTION
Add configs for the Fractal and Onion Creek adapters to the PCIe hot lists for BlueRidge and Fuji systems. These are new off-the-shelf Nvidia adapter versions of Shale and Narwhal respectively. Fractal is added with the same floor index value as Shale and Onion Creek is added with the same floor index value as Narwhal.

Tested:
* Put config on system with cards and verified correct number of cards and pcie_floor_index showed up in flight recorder.

Change-Id: I590271c9dd4a894957b24513bf29e489fcd189e2